### PR TITLE
Lock PitExit/Opponents League cohort matching to live player's effective class and refresh on League config changes

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -7,6 +7,13 @@
   - Deferred-reset apply path now uses pending identity only when it still matches the current observed session identity; otherwise pending is discarded and current observed identity is applied, preventing stale `B` apply when observed identity is `C`.
   - `A→B→A` stale-pending clear now also resets `_finishTimingSessionChangeDeferredInActiveLifecycle` so future defers log once again.
 
+- 2026-05-16 PitExit League cohort authority follow-up landed.
+  - `BuildRaceContextLeagueClassMatchDelegate()` now locks cohort authority to the live player effective class whenever League Class is enabled and the live player resolves valid, instead of allowing per-row player-resolution fallback to keep native-equivalent cohorts in some PitExit update states.
+  - Candidate rows must resolve a valid effective class to join that effective cohort; unresolved candidates are excluded in League-active effective mode.
+  - When League Class is enabled but live player effective class is unresolved, fallback remains native class-colour matching only when both rows have valid native class colours; otherwise `false` (no match-all).
+  - Added narrow League settings/definition change invalidation for Opponents/PitExit (`_opponentsEngine.Reset()` on next tick) to avoid stale colour-only carry-over after mode/definition toggles.
+  - PitExit timing/gap/countdown/loss/distance math unchanged; Opp race-slot ordering/gap math unchanged; CarSA/H2H/fuel unchanged.
+
 - 2026-05-15 RaceFinish deferred-identity stale-clear follow-up landed.
   - `UpdateFinishTiming(...)` now clears pending deferred session identity when observed identity reverts to current active identity before lifecycle exit (`A→B→A` transient churn), preventing stale deferred identity apply on later genuine session changes.
 

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -2,6 +2,12 @@
 
 - 2026-05-16: RaceFinish deferred-reset apply-path hardening validated: pending identity is applied only if it still matches current observed session identity; stale pending is discarded and active defer-log latch resets on churn reversion.
 
+- 2026-05-16: PitExit League cohort authority follow-up validated.
+  - when League Class is enabled and live player effective class resolves valid, PitExit/Opp race-context cohort matching now stays on effective-class authority (candidate rows must resolve valid effective class to match), preventing native-equivalent cohort carry-over with colour-only changes.
+  - when League Class is enabled but live player effective class is unresolved, native fallback remains guarded by valid native class colours on both rows (no match-all).
+  - added narrow League settings/definition-change invalidation path to refresh Opponents/PitExit cohort state on next tick.
+  - protected systems unchanged: PitExit timing/gap/countdown/loss/distance math, Opp race-slot ordering/gap math, CarSA, H2H, and fuel systems.
+
 - 2026-05-15: RaceFinish deferred identity stale-clear validated: transient `A→B→A` churn during active finish lifecycle now clears pending deferred identity, avoiding extra reset/fuel-recalc cycle from stale pending apply.
 
 - 2026-05-15: RaceFinish deferred-session detectability follow-up validated: deferred path now stores pending session identity without overwriting active finish-session identity, then applies one clean reset/identity update after lifecycle exit.

--- a/Docs/Subsystems/Opponents.md
+++ b/Docs/Subsystems/Opponents.md
@@ -116,6 +116,13 @@ Opponents now reads from:
   - PitExit selection outputs (`PredictedPositionInClass`, `CarsAheadAfterPitCount`, `PitExit.Ahead/Behind.*`, `PitExit.Summary`) now reliably use the effective-class cohort whenever enabled+player-resolved at update time; disabled/unresolved-player paths remain native fallback.
   - PitExit timing/gap/countdown/loss/distance math and Opp race-slot selection remain unchanged.
 
+- 2026-05-16 PitExit League cohort authority follow-up:
+  - when League Class is enabled and the live player effective class resolves valid, race-context class matching is locked to that effective class for PitExit/Opp cohort scans (candidate rows must resolve valid effective class to match);
+  - this prevents per-row player-resolution fallback states from preserving native-equivalent PitExit target cohorts while only class-colour presentation changes;
+  - when enabled but live player effective class is unresolved, fallback remains native class-colour matching only when both rows have native colours (no match-all);
+  - a narrow League settings/definition-change invalidation resets Opponents/PitExit on next update tick so mode/definition toggles do not leave stale PitExit cohort selections in the off-pit refresh window;
+  - pit-exit timing/gap/countdown/loss/distance math remains unchanged.
+
 
 - 2026-05-05 replay identity/gating follow-up:
   - ClassLeader/ClassBest race-context candidate rows built in `LalaLaunch` now require canonical identity (`ClassColor:CarNumber`) and no longer synthesize `car:{idx}` fallback identities;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5452,6 +5452,10 @@ namespace LaunchPlugin
                 return null;
             }
 
+            var livePlayerEffectiveClass = ResolveLivePlayerLeagueClassInfo();
+            bool enforceEffectiveMatching = livePlayerEffectiveClass.Valid && !string.IsNullOrWhiteSpace(livePlayerEffectiveClass.Name);
+            string normalizedLivePlayerClassName = enforceEffectiveMatching ? livePlayerEffectiveClass.Name.Trim() : string.Empty;
+
             return (playerRow, candidateRow) =>
             {
                 if (playerRow == null || candidateRow == null)
@@ -5464,10 +5468,21 @@ namespace LaunchPlugin
                     return true;
                 }
 
-                var playerEffectiveClass = ResolveLeagueClassPlayerInfo(
+                if (enforceEffectiveMatching)
+                {
+                    var candidateEffectiveClass = ResolveLeagueClassDriverInfo(candidateRow.UserID > 0 ? (int?)candidateRow.UserID : null, candidateRow.Name);
+                    if (!candidateEffectiveClass.Valid || string.IsNullOrWhiteSpace(candidateEffectiveClass.Name))
+                    {
+                        return false;
+                    }
+
+                    return string.Equals(normalizedLivePlayerClassName, candidateEffectiveClass.Name.Trim(), StringComparison.OrdinalIgnoreCase);
+                }
+
+                var playerEffectiveClassFromRow = ResolveLeagueClassPlayerInfo(
                     playerRow.UserID > 0 ? (int?)playerRow.UserID : null,
                     playerRow.Name);
-                if (!playerEffectiveClass.Valid || string.IsNullOrWhiteSpace(playerEffectiveClass.Name))
+                if (!playerEffectiveClassFromRow.Valid || string.IsNullOrWhiteSpace(playerEffectiveClassFromRow.Name))
                 {
                     if (string.IsNullOrWhiteSpace(playerRow.ClassColor) || string.IsNullOrWhiteSpace(candidateRow.ClassColor))
                     {
@@ -5477,7 +5492,7 @@ namespace LaunchPlugin
                     return string.Equals(candidateRow.ClassColor, playerRow.ClassColor, StringComparison.Ordinal);
                 }
 
-                string normalizedPlayerClassName = playerEffectiveClass.Name.Trim();
+                string normalizedPlayerClassName = playerEffectiveClassFromRow.Name.Trim();
 
                 var candidateEffectiveClass = ResolveLeagueClassDriverInfo(candidateRow.UserID > 0 ? (int?)candidateRow.UserID : null, candidateRow.Name);
                 if (!candidateEffectiveClass.Valid || string.IsNullOrWhiteSpace(candidateEffectiveClass.Name))
@@ -6124,6 +6139,7 @@ namespace LaunchPlugin
         private LaunchPluginSettings _subscribedLeagueClassSettings;
         private LaunchPluginSettings _subscribedPitFuelControlSettings;
         private bool _applyingPitFuelControlDataAction;
+        private bool _leagueClassOpponentsRefreshPending;
         private List<LeagueClassDefinition> _subscribedLeagueClassDefinitions;
         private readonly HashSet<LeagueClassDefinition> _leagueClassDefinitionSubscriptions = new HashSet<LeagueClassDefinition>();
         private bool _isSavingSettings;
@@ -10042,6 +10058,11 @@ namespace LaunchPlugin
             EvaluateDarkMode(pluginManager);
             ApplyLeagueClassEnableModeGuard();
             MaybeRefreshLeagueClassPreview(pluginManager);
+            if (_leagueClassOpponentsRefreshPending)
+            {
+                _opponentsEngine?.Reset();
+                _leagueClassOpponentsRefreshPending = false;
+            }
             if (!data.GameRunning || data.NewData == null) return;
 
             _isRefuelSelected = IsRefuelSelected(pluginManager);
@@ -14020,6 +14041,7 @@ namespace LaunchPlugin
                 HookLeagueClassDefinitions(_subscribedLeagueClassSettings?.LeagueClassDefinitions);
                 OnPropertyChanged(nameof(LeagueClassStatus));
                 OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+                _leagueClassOpponentsRefreshPending = true;
                 return;
             }
 
@@ -14034,6 +14056,7 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
             OnPropertyChanged(nameof(LeagueClassShowCsvSection));
             OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
+            _leagueClassOpponentsRefreshPending = true;
         }
 
         private void HookLeagueClassDefinitions(List<LeagueClassDefinition> definitions)
@@ -14095,6 +14118,7 @@ namespace LaunchPlugin
         private void OnLeagueClassDefinitionPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+            _leagueClassOpponentsRefreshPending = true;
             SaveSettings();
         }
 


### PR DESCRIPTION
### Motivation
- Prevent PitExit/Opponents from accidentally keeping native-equivalent cohorts when League Class is enabled and the live player has a resolved effective class, and avoid stale cohort selections after League settings/definition toggles.
- Ensure native fallback remains safe by requiring non-empty native class colours on both rows when effective-class resolution is unavailable.

### Description
- `BuildRaceContextLeagueClassMatchDelegate()` now inspects the live player's effective class and, when it is valid, enforces matching against that live effective class and rejects candidate rows that do not resolve a valid effective class, locking cohort authority to the live player.
- When the live player effective class is unresolved the delegate falls back to native class-colour matching only when both `playerRow.ClassColor` and `candidateRow.ClassColor` are non-empty, otherwise it returns `false` to avoid match-all behaviour.
- Added `_leagueClassOpponentsRefreshPending` and logic to call `_opponentsEngine?.Reset()` on the next tick when League settings or League class definitions change so Opponents/PitExit do not retain stale cohort selections.
- Documentation updates to `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`, and `Docs/Subsystems/Opponents.md` describing the follow-up fixes and behavior guarantees.

### Testing
- Performed a solution build which completed successfully with the modified code.
- Executed the repository's automated test suite and observed all tests passing after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0867b87340832faffd29788d75bfdb)