### PR TITLE
Strategy: change default PreRace mode to Single Stop for new planner state and presets

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2385,3 +2385,11 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - `IsPresetModified()` race-basis comparisons now use effective basis/length (invalid effective basis no longer reports false clean match).
 
 - Final cleanup tightened race-basis invalidation/notification paths so applied-preset removal while Preset owner is active now immediately invalidates outputs (`Select a race preset`) and prevents stale strategy display.
+
+## 2026-05-16 — Strategy PreRace default mode changed to Single Stop
+- Classification: **both** (default workflow behavior update + docs alignment).
+- Updated Strategy default PreRace mode from `Multi Stop` to `Single Stop` for new/default planner state and new preset template creation.
+- Preserved persistence/backward compatibility semantics:
+  - existing saved profile/preset `PreRaceMode` values are unchanged,
+  - legacy persisted `Auto` value (`3`) normalization behavior remains unchanged (`3 -> Multi Stop`).
+- No planner math/race-basis/live-detect/runtime fuel/dash export behavior changes.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2393,3 +2393,4 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
   - existing saved profile/preset `PreRaceMode` values are unchanged,
   - legacy persisted `Auto` value (`3`) normalization behavior remains unchanged (`3 -> Multi Stop`).
 - No planner math/race-basis/live-detect/runtime fuel/dash export behavior changes.
+- PR #726 follow-up fix: `LoadProfileData()` car-change reset path now preserves the already loaded persisted `PreRaceMode` instead of forcing the reset default; Single Stop default remains active for cold-start/default state.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1402,3 +1402,8 @@ Branch: work
 - 2026-05-16: Strategy owner-vs-effective race-basis semantics tightened; dirty-state and effective visibility now derive from effective basis helpers.
 
 - Final PR #723 cleanup: effective race-basis notification/invalidation now centralised in FuelCalcs; preset removal while Preset owner active now clears stale strategy outputs immediately.
+
+- 2026-05-16: Strategy PreRace default mode changed from Multi Stop to Single Stop for new/default planner state and new preset template creation.
+  - existing saved profile/preset PreRaceMode values are preserved;
+  - legacy persisted Auto (`3`) normalization remains unchanged (`3 -> Multi Stop`);
+  - no planner math, race-basis ownership, Live Detect, runtime fuel model, or dash export behavior changes.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1407,3 +1407,4 @@ Branch: work
   - existing saved profile/preset PreRaceMode values are preserved;
   - legacy persisted Auto (`3`) normalization remains unchanged (`3 -> Multi Stop`);
   - no planner math, race-basis ownership, Live Detect, runtime fuel model, or dash export behavior changes.
+  - follow-up fix: profile/car-load reset path now preserves loaded persisted PreRace mode (No Stop/Single Stop/Multi Stop) instead of overwriting to default Single Stop on car change.

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2527,7 +2527,7 @@ namespace LaunchPlugin
         set { IsContingencyInLaps = !value; }
     }
 
-    private int _selectedPreRaceMode = (int)PreRaceMode.MultiStop;
+    private int _selectedPreRaceMode = (int)PreRaceMode.SingleStop;
     public int SelectedPreRaceMode
     {
         get => _selectedPreRaceMode;
@@ -2693,7 +2693,7 @@ namespace LaunchPlugin
         }
     }
 
-    private void ResetStrategyInputs(bool preserveMaxFuel = false, bool preserveRaceDuration = false)
+    private void ResetStrategyInputs(bool preserveMaxFuel = false, bool preserveRaceDuration = false, bool preservePreRaceMode = false)
     {
         // Reset race-specific parameters to sensible defaults
         if (!preserveRaceDuration)
@@ -2702,7 +2702,10 @@ namespace LaunchPlugin
             this.RaceLaps = 20;
             this.RaceMinutes = 40;
         }
-        this.SelectedPreRaceMode = (int)PreRaceMode.SingleStop;
+        if (!preservePreRaceMode)
+        {
+            this.SelectedPreRaceMode = (int)PreRaceMode.SingleStop;
+        }
 
         // Smartly default Max Fuel: use the profile base tank (or default).
         if (!preserveMaxFuel)
@@ -4415,7 +4418,7 @@ namespace LaunchPlugin
                 {
                     // When switching cars, reinitialize the max-fuel override from the new car's tank size
                     // (or default) but keep the user's race duration/type selections intact.
-                    ResetStrategyInputs(preserveMaxFuel: false, preserveRaceDuration: true);
+                    ResetStrategyInputs(preserveMaxFuel: false, preserveRaceDuration: true, preservePreRaceMode: true);
                 }
 
                 OnPropertyChanged(nameof(MaxFuelOverrideMaximum));

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2702,7 +2702,7 @@ namespace LaunchPlugin
             this.RaceLaps = 20;
             this.RaceMinutes = 40;
         }
-        this.SelectedPreRaceMode = (int)PreRaceMode.MultiStop;
+        this.SelectedPreRaceMode = (int)PreRaceMode.SingleStop;
 
         // Smartly default Max Fuel: use the profile base tank (or default).
         if (!preserveMaxFuel)
@@ -3113,7 +3113,7 @@ namespace LaunchPlugin
             Type = RacePresetType.TimeLimited,
             RaceLaps = null,
             RaceMinutes = 40,
-            PreRaceMode = (int)PreRaceMode.MultiStop,
+            PreRaceMode = (int)PreRaceMode.SingleStop,
             TireChangeTimeSec = 23,
             MaxFuelPercent = 100,
             LegacyMaxFuelLitres = null,

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -976,8 +976,8 @@ namespace LaunchPlugin
         public double Fuel_Setup_FuelLevel { get; private set; }
         public bool Fuel_Setup_FuelLevelValid { get; private set; }
         public string Fuel_Setup_FuelLevelSource { get; private set; } = "none";
-        public int PreRace_Selected { get; private set; } = 2;
-        public string PreRace_SelectedText { get; private set; } = "Multi Stop";
+        public int PreRace_Selected { get; private set; } = 1;
+        public string PreRace_SelectedText { get; private set; } = "Single Stop";
         public double PreRace_Stints { get; private set; }
         public double PreRace_TotalFuelNeeded { get; private set; }
         public double PreRace_FuelDelta { get; private set; }
@@ -18558,8 +18558,8 @@ namespace LaunchPlugin
             Contingency_Laps = 0;
             Contingency_Source = "none";
 
-            PreRace_Selected = 2;
-            PreRace_SelectedText = "Multi Stop";
+            PreRace_Selected = 1;
+            PreRace_SelectedText = "Single Stop";
             PreRace_Stints = 0;
             PreRace_TotalFuelNeeded = 0;
             PreRace_FuelDelta = 0;

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -2024,7 +2024,7 @@ namespace LaunchPlugin
                     AntiStallThreshold = 10.0,
 
                     // Fuel & Pit Properties
-                    PreRaceMode = 3,
+                    PreRaceMode = 1,
                     TireChangeTime = 22,
                     RefuelRate = 3.7,
                     RefuelRateLocked = false,


### PR DESCRIPTION
### Motivation
- Update the default pre-race pit strategy for newly created planner state and preset templates from `Multi Stop` to `Single Stop` to better match the intended default workflow.
- Preserve existing persistence and backward-compatibility semantics so previously saved profiles/presets and legacy `Auto` normalization remain unchanged.
- Ensure no changes to planner math, live-detect, runtime fuel models, or dash export behavior while adjusting only the default UI/profile/template state.

### Description
- Changed the runtime default used when resetting strategy inputs by setting `SelectedPreRaceMode` to `PreRaceMode.SingleStop` in `FuelCalcs.ResetStrategyInputs`.
- Updated the default preset template by setting `PreRaceMode` to `PreRaceMode.SingleStop` in `FuelCalcs.BuildDefaultPresetTemplate` and ensured `CreatePresetFromDefaults` uses the new template.
- Adjusted initial/default UI values in `LalaLaunch` by setting `PreRace_Selected = 1` and `PreRace_SelectedText = "Single Stop"` in both the field declarations and object reset initialization.
- Updated the built-in "Default Settings" profile in `ProfilesManagerViewModel` to set `PreRaceMode = 1` for new installs, and added corresponding changelog and repo status entries in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`.

### Testing
- Performed a full project build which completed successfully.
- Ran the existing automated unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a086a2645f4832fb0c5e37234b24483)