### PR TITLE
Audit Property Snapshot grouping and add export‑review Codex contract

### DIFF
--- a/Docs/Internal/CODEX_CONTRACT.txt
+++ b/Docs/Internal/CODEX_CONTRACT.txt
@@ -134,6 +134,15 @@ Do NOT change any of the following without updating docs:
 
 All changes must be reflected in canonical docs in the same task.
 
+Property Snapshot contract (mandatory when SimHub exports/properties change):
+
+* If a task adds, removes, renames, or behavior-changes any SimHub export/property, review `LalaLaunch.ResolvePropertySnapshotGroup(...)` in the same task.
+* Add newly introduced exports to the appropriate existing Property Snapshot group.
+* Remove snapshot-group expectations only when the underlying export/property is actually removed.
+* Confirm group ownership remains correct (Fuel/Strategy, Car/Opp/H2H, Pit/PitExit, Shift Assist, Message System, League Class, Raw Debug).
+* If snapshot behavior/UI wording/contracts changed, update relevant docs in the same task (`SimHubParameterInventory`, `Plugin_UI_Tooltips`, `Development_Changelog`, `RepoStatus`, and any affected subsystem/user docs).
+* Verification output must explicitly state: `Property Snapshot list reviewed: yes/no, with reason.`
+
 ---
 
 ## 8. C# and Dependency Rules

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,10 @@
+- 2026-05-18: Property Snapshot group audit + Codex contract guardrail.
+  - audited Property Snapshot grouping against current `AttachCore`/`AttachVerbose` export surface and inventory/changelog references;
+  - updated snapshot grouping coverage so `Race.*`, `RaceFinish.*`, `ClassBest.*`, and `ClassLeader.*` map into `Car/Opp/H2H` (instead of defaulting to `Raw Debug`);
+  - grouped `Pace.*` and `Surface.*` into `Fuel/Strategy` to keep race-planning fuel/pace observability aligned with existing snapshot semantics;
+  - no export names changed and no runtime subsystem calculations were modified;
+  - added mandatory `CODEX_CONTRACT` rule requiring same-task Property Snapshot review whenever SimHub exports/properties are added/removed/renamed/behavior-changed, with required verification line: `Property Snapshot list reviewed: yes/no, with reason.`
+
 - 2026-05-17: Strategy Planner profile fuel preview stale-label fix + Property Snapshot include alignment.
   - fixed track/profile clear/reload UI refresh so Profile-mode AVG/ECO/MAX preview labels immediately clear to neutral (`-`) when selected profile/track fuel data is missing/cleared, without requiring a Live Snapshot -> Profile toggle.
   - root cause: `ResetTrackScopedProfileData()` reset display fields but did not raise `PropertyChanged` for `ProfileAvgFuelDisplay`/related AVG row bindings, allowing stale text to remain until a later mode-driven refresh.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,10 @@
+- 2026-05-18: Property Snapshot grouping audit + contract guardrail validated.
+  - audited Property Snapshot group mapping against current plugin export surface (`AttachCore`/`AttachVerbose`) and internal inventory/changelog references.
+  - expanded grouping coverage so `Race.*`, `RaceFinish.*`, `ClassBest.*`, and `ClassLeader.*` capture under `Car/Opp/H2H` instead of defaulting to `Raw Debug`.
+  - grouped `Pace.*` and `Surface.*` under `Fuel/Strategy` for planning/fuel-context snapshot visibility.
+  - no export/property names changed and no runtime subsystem logic changed.
+  - `Docs/Internal/CODEX_CONTRACT.txt` now includes a standing mandatory rule: any task that adds/removes/renames/behavior-changes SimHub exports/properties must review/update Property Snapshot grouping and explicitly report `Property Snapshot list reviewed: yes/no, with reason.`
+
 - 2026-05-17: Strategy Planner profile preview stale-label regression fix validated.
   - Profile-mode AVG/ECO/MAX preview row now clears immediately on missing/deleted track fuel context (no Live Snapshot toggle required).
   - fix is UI-refresh scoped (`PropertyChanged` on profile preview display fields during track-scoped reset); no runtime DATA authority, pit command behavior, or refuel-formula behavior changes.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -13721,8 +13721,27 @@ namespace LaunchPlugin
         private static string ResolvePropertySnapshotGroup(string propertyName)
         {
             if (propertyName.StartsWith("Car.Debug.", StringComparison.Ordinal)) return "RawDebug";
-            if (propertyName.StartsWith("Fuel.", StringComparison.Ordinal) || propertyName.StartsWith("Strategy", StringComparison.Ordinal)) return "FuelStrategy";
-            if (propertyName.StartsWith("Car.", StringComparison.Ordinal) || propertyName.StartsWith("Opp.", StringComparison.Ordinal) || propertyName.StartsWith("H2H", StringComparison.Ordinal) || propertyName.StartsWith("LapRef.", StringComparison.Ordinal)) return "CarOppH2H";
+
+            if (propertyName.StartsWith("Fuel.", StringComparison.Ordinal)
+                || propertyName.StartsWith("Strategy", StringComparison.Ordinal)
+                || propertyName.StartsWith("Pace.", StringComparison.Ordinal)
+                || propertyName.StartsWith("Surface.", StringComparison.Ordinal))
+            {
+                return "FuelStrategy";
+            }
+
+            if (propertyName.StartsWith("Car.", StringComparison.Ordinal)
+                || propertyName.StartsWith("Opp.", StringComparison.Ordinal)
+                || propertyName.StartsWith("H2H", StringComparison.Ordinal)
+                || propertyName.StartsWith("LapRef.", StringComparison.Ordinal)
+                || propertyName.StartsWith("Race.", StringComparison.Ordinal)
+                || propertyName.StartsWith("RaceFinish.", StringComparison.Ordinal)
+                || propertyName.StartsWith("ClassBest.", StringComparison.Ordinal)
+                || propertyName.StartsWith("ClassLeader.", StringComparison.Ordinal))
+            {
+                return "CarOppH2H";
+            }
+
             if (propertyName.StartsWith("Pit.", StringComparison.Ordinal) || propertyName.StartsWith("PitExit.", StringComparison.Ordinal)) return "PitPitExit";
             if (propertyName.StartsWith("ShiftAssist.", StringComparison.Ordinal)) return "ShiftAssist";
             if (propertyName.StartsWith("MSG", StringComparison.Ordinal) || propertyName.StartsWith("Message", StringComparison.Ordinal)) return "MessageSystem";


### PR DESCRIPTION
### Motivation

- Ensure the Property Snapshot debug capture reflects the current plugin export surface so recently added exports are captured under the correct groups instead of the `Raw Debug` fallback. 
- Make the export / snapshot review a mandatory step in the Codex contract to prevent silent drift when SimHub exports/properties are added/removed/renamed/changed. 

### Description

- Updated `ResolvePropertySnapshotGroup(...)` in `LalaLaunch.cs` to map additional export families into existing snapshot groups (`Race.*`, `RaceFinish.*`, `ClassBest.*`, `ClassLeader.*` -> `Car/Opp/H2H`; `Pace.*`, `Surface.*` -> `Fuel/Strategy`).
- Added a mandatory Property Snapshot review rule to `Docs/Internal/CODEX_CONTRACT.txt` under the **No Silent Contract Drift** section requiring same-task review and an explicit verification line `Property Snapshot list reviewed: yes/no, with reason.`
- Documented the audit and contract update in `Docs/Internal/Development_Changelog.md` and recorded validated-state notes in `Docs/RepoStatus.md`.

### Testing

- Ran repository grep/scan checks (`rg`) to validate UI checkbox wiring and that group names map to the same `Settings.PropertySnapshotGroup*` flags and confirm `GlobalSettingsView.xaml` group checkboxes remain unchanged. 
- Cross-checked the new grouping against the plugin `AttachCore`/`AttachVerbose` export surface by extracting registered export prefixes from `LalaLaunch.cs` (small Python check) to ensure families now map to intended groups. 
- Performed static code inspection of the snapshot writer (`WritePropertySnapshotCsv`, `IsPropertySnapshotGroupEnabled`, `ResolvePropertySnapshotGroup`) to ensure no runtime logic or export names were modified and the writer still filters by group as before. 
- Attempted an automated build with `dotnet build LaunchPlugin.sln` but the environment lacked `dotnet` so compilation could not be executed here (failure: `/bin/bash: dotnet: command not found`).

Property Snapshot list reviewed: yes, because the grouping changes were made after cross-checking `AttachCore`/`AttachVerbose` registrations and `Docs/Internal/SimHubParameterInventory.md`/`Development_Changelog.md` entries, and no export names or runtime subsystem calculations were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b07bc9380832f9d1d7284dbb116fc)