### PR TITLE
Remove temporary RaceDenom and LeagueSubclassCount diagnostics

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -68,20 +68,11 @@
 
 - 2026-05-18: League race class denominator source corrected to strict `DriverInfo.Drivers##` subclass cohort for League ON.
   - `GetLeagueClassPlayerDriverCount()` and `ResolveCanonicalPlayerClassRaceDenominator()` support paths now use strict current-session `DriverInfo.Drivers##` row scanning/resolution for League subclass counts (pace-car excluded), with no CSV membership fallback as race denominator authority.
-  - `Race.PlayerClassFieldSize` / `RaceFinish.PlayerClassFieldSize` canonical seam now uses strict League subclass count when available, else native/session fallback only; RaceDenom hot-path logging remains bounded without full roster recount.
-
-- 2026-05-18: Fixed League subclass diagnostic row scan fallback identity coverage and removed RaceDenom hot-path recount.
-  - `GetLeagueClassPlayerDriverCount()` no longer rejects rows before reading fallback identity fields (`UserNameRaw` / `UserNameProcessed`), and now counts valid rows when any usable identity (`UserID`, `UserName`, `CarIdx`, `CarNumber`) is present; pace-car exclusion and bounded diagnostics retained.
-  - `LogRaceDenominatorResolution()` no longer calls `GetLeagueClassPlayerDriverCount()`; removed misleading `csvDriverCount` payload to avoid per-tick full roster recount from RaceDenom diagnostics.
-
-- 2026-05-17: Added bounded League subclass current-session count diagnostics in `GetLeagueClassPlayerDriverCount()`.
-  - New `[LalaPlugin:LeagueSubclassCount]` log reports session-row vs CSV fallback counts (valid/pace/resolved/matching/unresolved) and emits only when signature changes, to prove whether current-session cohort counting is available or falling back to CSV membership.
+  - `Race.PlayerClassFieldSize` / `RaceFinish.PlayerClassFieldSize` canonical seam now uses strict League subclass count when available, else native/session fallback only.
 
 - 2026-05-17: Fixed live `Race.PlayerClassFieldSize` attach path to call canonical race denominator helper directly.
   - Removed the remaining indirection method for live export so League-enabled live publish cannot take a stale/legacy override path; `RaceFinish.PlayerClassFieldSize` freeze path and denominator helper logic unchanged.
 
-- 2026-05-16: Added bounded race denominator branch diagnostics in `LalaLaunch` for `Race.PlayerClassFieldSize` / `RaceFinish.PlayerClassFieldSize` investigation.
-  - New `[LalaPlugin:RaceDenom]` info log emits only when denominator branch/signature/result changes, including branch, league toggle, roster/native/opponent counters, and player native/effective class context.
 - 2026-05-18: Property Snapshot group audit + Codex contract guardrail.
   - audited Property Snapshot grouping against current `AttachCore`/`AttachVerbose` export surface and inventory/changelog references;
   - updated snapshot grouping coverage so `Race.*`, `RaceFinish.*`, `ClassBest.*`, and `ClassLeader.*` map into `Car/Opp/H2H` (instead of defaulting to `Raw Debug`);

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -46,20 +46,11 @@
 
 - 2026-05-18: League race class denominator source corrected to strict `DriverInfo.Drivers##` subclass cohort for League ON.
   - `GetLeagueClassPlayerDriverCount()` and `ResolveCanonicalPlayerClassRaceDenominator()` support paths now use strict current-session `DriverInfo.Drivers##` row scanning/resolution for League subclass counts (pace-car excluded), with no CSV membership fallback as race denominator authority.
-  - `Race.PlayerClassFieldSize` / `RaceFinish.PlayerClassFieldSize` canonical seam now uses strict League subclass count when available, else native/session fallback only; RaceDenom hot-path logging remains bounded without full roster recount.
-
-- 2026-05-18: Fixed League subclass diagnostic row scan fallback identity coverage and removed RaceDenom hot-path recount.
-  - `GetLeagueClassPlayerDriverCount()` no longer rejects rows before reading fallback identity fields (`UserNameRaw` / `UserNameProcessed`), and now counts valid rows when any usable identity (`UserID`, `UserName`, `CarIdx`, `CarNumber`) is present; pace-car exclusion and bounded diagnostics retained.
-  - `LogRaceDenominatorResolution()` no longer calls `GetLeagueClassPlayerDriverCount()`; removed misleading `csvDriverCount` payload to avoid per-tick full roster recount from RaceDenom diagnostics.
-
-- 2026-05-17: Added bounded diagnostics to prove current-session League subclass cohort count availability.
-  - `GetLeagueClassPlayerDriverCount()` now logs `[LalaPlugin:LeagueSubclassCount]` on signature change with session-row/resolution stats and CSV fallback comparison; behavior/output semantics unchanged.
+  - `Race.PlayerClassFieldSize` / `RaceFinish.PlayerClassFieldSize` canonical seam now uses strict League subclass count when available, else native/session fallback only.
 
 - 2026-05-17: Live race class denominator publish path tightened.
   - `Race.PlayerClassFieldSize` now attaches directly to `ResolveCanonicalPlayerClassRaceDenominator(...)`; no League-specific live override path remains. `RaceFinish.PlayerClassFieldSize` path unchanged.
 
-- 2026-05-16: Added bounded runtime diagnostics for race class denominator resolution.
-  - `LalaLaunch` now logs `[LalaPlugin:RaceDenom]` only on denominator result/signature change so live sessions can identify which canonical branch won (`roster`, `native`, game-data/telemetry fallbacks, or none) without per-tick spam.
 - 2026-05-18: Property Snapshot grouping audit + contract guardrail validated.
   - audited Property Snapshot group mapping against current plugin export surface (`AttachCore`/`AttachVerbose`) and internal inventory/changelog references.
   - expanded grouping coverage so `Race.*`, `RaceFinish.*`, `ClassBest.*`, and `ClassLeader.*` capture under `Car/Opp/H2H` instead of defaulting to `Raw Debug`.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -900,9 +900,6 @@ namespace LaunchPlugin
         private string _raceFinishClassBestLap = "-";
         private int _raceFinishPlayerOverallFieldSize;
         private int _raceFinishPlayerClassFieldSize;
-        private string _raceDenominatorDebugSignature = string.Empty;
-        private int _raceDenominatorDebugResult = int.MinValue;
-        private string _leagueSubclassCountDebugSignature = string.Empty;
         private int _playerCarIdxLastTick = -1;
         private double _lastClassLeaderLapPct = double.NaN;
         private double _lastOverallLeaderLapPct = double.NaN;
@@ -5860,7 +5857,6 @@ namespace LaunchPlugin
             strictCount = 0;
             if (player == null || !player.Valid || string.IsNullOrWhiteSpace(player.Name))
             {
-                LogLeagueSubclassCountDiagnostics(string.Empty, null, 0, 0, 0, 0, 0, 0, 0, string.Empty, string.Empty, "player_unresolved", "drivers_rows");
                 return false;
             }
 
@@ -5874,8 +5870,6 @@ namespace LaunchPlugin
             int? playerUserId;
             string playerName;
             TryGetLivePlayerIdentityPreview(out playerUserId, out playerName);
-            string matchSamples = string.Empty;
-            string unresolvedSamples = string.Empty;
 
             for (int i = 1; i <= 64; i++)
             {
@@ -5914,11 +5908,6 @@ namespace LaunchPlugin
                 if (userId <= 0 && string.IsNullOrWhiteSpace(name))
                 {
                     unresolvedRows++;
-                    if (unresolvedRows <= 3)
-                    {
-                        unresolvedSamples += (unresolvedSamples.Length > 0 ? ", " : string.Empty)
-                            + $"{(carIdx >= 0 ? ("carIdx:" + carIdx.ToString(CultureInfo.InvariantCulture)) : "carIdx:-1")}:{(carNumber ?? string.Empty)}";
-                    }
                     continue;
                 }
 
@@ -5935,11 +5924,6 @@ namespace LaunchPlugin
                 if (!info.Valid || string.IsNullOrWhiteSpace(info.Name))
                 {
                     unresolvedRows++;
-                    if (unresolvedRows <= 3)
-                    {
-                        unresolvedSamples += (unresolvedSamples.Length > 0 ? ", " : string.Empty)
-                            + $"{(userId > 0 ? userId.ToString(CultureInfo.InvariantCulture) : "0")}:{(name ?? string.Empty)}";
-                    }
                     continue;
                 }
 
@@ -5947,15 +5931,8 @@ namespace LaunchPlugin
                 if (string.Equals(info.Name, player.Name, StringComparison.OrdinalIgnoreCase))
                 {
                     count++;
-                    if (count <= 3)
-                    {
-                        matchSamples += (matchSamples.Length > 0 ? ", " : string.Empty)
-                            + $"{(userId > 0 ? userId.ToString(CultureInfo.InvariantCulture) : "0")}:{(name ?? string.Empty)}";
-                    }
                 }
             }
-
-            LogLeagueSubclassCountDiagnostics(player.Name, playerUserId, sessionRows, validRows, paceCars, resolvedRows, count, 0, unresolvedRows, matchSamples, unresolvedSamples, count > 0 ? "strict_match" : "strict_no_match", "drivers_rows");
             strictCount = count;
             return count > 0;
         }
@@ -5969,46 +5946,6 @@ namespace LaunchPlugin
 
             string userName = SafeReadStringProperty(driversBasePath + ".UserName");
             return string.Equals((userName ?? string.Empty).Trim(), "Pace Car", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private void LogLeagueSubclassCountDiagnostics(
-            string playerClassName,
-            int? playerUserId,
-            int sessionRows,
-            int validRows,
-            int paceCars,
-            int resolvedRows,
-            int matchingRows,
-            int csvRegisteredClassCount,
-            int unresolvedRows,
-            string sampleMatches,
-            string sampleUnresolved,
-            string source,
-            string rowSource)
-        {
-            string signature = string.Format(
-                CultureInfo.InvariantCulture,
-                "rowSource={0}|playerClass={1}|playerUserId={2}|sessionRows={3}|validRows={4}|paceCars={5}|resolvedRows={6}|matchingRows={7}|csvRegisteredClassCount={8}|unresolvedRows={9}|source={10}",
-                rowSource ?? string.Empty,
-                playerClassName ?? string.Empty,
-                playerUserId.HasValue ? playerUserId.Value.ToString(CultureInfo.InvariantCulture) : "0",
-                sessionRows,
-                validRows,
-                paceCars,
-                resolvedRows,
-                matchingRows,
-                csvRegisteredClassCount,
-                unresolvedRows,
-                source ?? string.Empty);
-
-            if (string.Equals(signature, _leagueSubclassCountDebugSignature, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            _leagueSubclassCountDebugSignature = signature;
-            SimHub.Logging.Current.Info(
-                $"[LalaPlugin:LeagueSubclassCount] source={source} rowSource={rowSource} playerClass='{playerClassName ?? string.Empty}' playerUserId={(playerUserId ?? 0)} sessionRows={sessionRows} validRows={validRows} paceCars={paceCars} resolvedRows={resolvedRows} matchingRows={matchingRows} csvRegisteredClassCount={csvRegisteredClassCount} unresolvedRows={unresolvedRows} sampleMatches='{sampleMatches ?? string.Empty}' sampleUnresolved='{sampleUnresolved ?? string.Empty}'");
         }
 
         private int GetNativePlayerClassDriverCount()
@@ -9122,21 +9059,18 @@ namespace LaunchPlugin
             int playerClassRosterCount = CountPlayerClassDriversRowsExcludingPaceCar();
             if (playerClassRosterCount > 0)
             {
-                LogRaceDenominatorResolution("roster", playerClassRosterCount, pluginManager, playerClassRosterCount);
                 return playerClassRosterCount;
             }
 
             int nativeDriverCount = GetNativePlayerClassDriverCount();
             if (nativeDriverCount > 0)
             {
-                LogRaceDenominatorResolution("native", nativeDriverCount, pluginManager, playerClassRosterCount, nativeDriverCount);
                 return nativeDriverCount;
             }
 
             int classOpponentsCount = SafeReadInt(pluginManager, "DataCorePlugin.GameData.PlayerClassOpponentsCount", int.MinValue);
             if (classOpponentsCount >= 0)
             {
-                LogRaceDenominatorResolution("gamedata_playerClassOpp", classOpponentsCount, pluginManager, playerClassRosterCount, nativeDriverCount, classOpponentsCount);
                 return classOpponentsCount;
             }
 
@@ -9144,7 +9078,6 @@ namespace LaunchPlugin
             if (classOpponentsCount >= 0)
             {
                 int result = classOpponentsCount + 1;
-                LogRaceDenominatorResolution("telemetry_oppInClass_plusPlayer", result, pluginManager, playerClassRosterCount, nativeDriverCount, int.MinValue, classOpponentsCount);
                 return result;
             }
 
@@ -9152,53 +9085,10 @@ namespace LaunchPlugin
             if (simHubClassOpponentsCount >= 0)
             {
                 int result = simHubClassOpponentsCount + 1;
-                LogRaceDenominatorResolution("simhubNewData_oppInClass_plusPlayer", result, pluginManager, playerClassRosterCount, nativeDriverCount, int.MinValue, int.MinValue, simHubClassOpponentsCount);
                 return result;
             }
 
-            LogRaceDenominatorResolution("none", 0, pluginManager, playerClassRosterCount, nativeDriverCount);
             return 0;
-        }
-
-        private void LogRaceDenominatorResolution(
-            string branch,
-            int result,
-            PluginManager pluginManager,
-            int rosterCount,
-            int nativeCount = int.MinValue,
-            int gamePlayerClassOpp = int.MinValue,
-            int telemetryOppInClass = int.MinValue,
-            int simHubNewDataOppInClass = int.MinValue)
-        {
-            int leagueOn = (Settings?.LeagueClassEnabled == true) ? 1 : 0;
-            int gameOpp = SafeReadInt(pluginManager, "DataCorePlugin.GameData.OpponentsCount", int.MinValue);
-            string playerNative = ResolvePlayerNativeClassName() ?? string.Empty;
-            var playerLeague = ResolveLivePlayerLeagueClassInfo();
-            string playerLeagueName = playerLeague.Valid && !string.IsNullOrWhiteSpace(playerLeague.Name) ? playerLeague.Name : string.Empty;
-
-            string signature = string.Format(
-                CultureInfo.InvariantCulture,
-                "branch={0}|league={1}|roster={2}|native={3}|gamePlayerClassOpp={4}|telemetryOppInClass={5}|simHubNewDataOppInClass={6}|gameOpp={7}|playerNative={8}|playerLeague={9}",
-                branch,
-                leagueOn,
-                rosterCount,
-                nativeCount,
-                gamePlayerClassOpp,
-                telemetryOppInClass,
-                simHubNewDataOppInClass,
-                gameOpp,
-                playerNative,
-                playerLeagueName);
-
-            if (result == _raceDenominatorDebugResult && string.Equals(signature, _raceDenominatorDebugSignature, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            _raceDenominatorDebugResult = result;
-            _raceDenominatorDebugSignature = signature;
-            SimHub.Logging.Current.Info(
-                $"[LalaPlugin:RaceDenom] playerClassDenom result={result} {signature}");
         }
 
         private int CountValidDriversRowsExcludingPaceCar()


### PR DESCRIPTION
### Motivation
- Remove transient diagnostic instrumentation that was added to investigate RaceFinish denominator and League subclass counting now that behavior is validated and a dash fallback is accepted.  
- Keep runtime clean for release while preserving existing denominator/counting behavior and subsystem boundaries.  

### Description
- Deleted the runtime diagnostic plumbing for race-denominator resolution by removing `LogRaceDenominatorResolution(...)` callsites and its helper state, while leaving `ResolveCanonicalPlayerClassRaceDenominator(...)` return-paths and branch order unchanged.  
- Removed the League subclass diagnostic routine `LogLeagueSubclassCountDiagnostics(...)`, its signature cache state and temporary sample capture strings, and the per-row sample plumbing from `TryCountCurrentSessionLeagueSubclassFromDrivers(...)`.  
- Removed the debug signature fields used only for those logs (`_raceDenominatorDebugSignature`, `_raceDenominatorDebugResult`, `_leagueSubclassCountDebugSignature`) and eliminated the transient sample variables (`sampleMatches`, `sampleUnresolved`).  
- Cleaned investigation-only notes from `Docs/RepoStatus.md` and `Docs/Internal/Development_Changelog.md` while retaining the definitive architecture statements about `DriverInfo.Drivers##` authority and CSV non-authority for denominators.  

### Testing
- Ran a repository-wide search with `rg` to confirm removal of diagnostic identifiers and logging callsites, which returned no remaining `[LalaPlugin:RaceDenom]` or `[LalaPlugin:LeagueSubclassCount]` usages (success).  
- Attempted to run `dotnet build -v minimal` to compile the project but the environment lacks the .NET SDK (`dotnet: command not found`), so an in-container build could not be completed (automated build failed due to missing tool).  
- Property Snapshot list reviewed: yes — no SimHub export/property names were added/removed/renamed in this change so no Property Snapshot grouping updates were required.  

No denominator behaviour changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4a817ba8832fa33bfaf621b77e77)