### PR TITLE
Strategy: separate tyre-stop intent from tyre timing (Preset TyreStopExpected)

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,4 +1,10 @@
 
+- 2026-05-19: PR #745 review follow-up fixed preset editor intent hydration for legacy presets.
+  - Preset clone/copy paths now persist explicit edit/save intent via `source.ResolvedTyreStopExpected` instead of nullable `source.TyreStopExpected`.
+  - Preset Manager checkbox now opens legacy presets with resolved checked state (`>0` true, `==0` false, missing/invalid true) and saves explicit `TyreStopExpected`.
+  - Strategy math and live pit prediction/export seams unchanged.
+
+
 - 2026-05-19: Strategy preset tyre intent separation implemented.
   - Added preset field `TyreStopExpected` with compatibility resolution from legacy `TireChangeTimeSec` (`>0 => true`, `==0 => false`, missing/invalid => `true`).
   - Preset apply no longer overwrites Strategy `TireChangeTime` slider seconds; apply now sets tyre intent only.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,11 @@
+
+- 2026-05-19: Strategy preset tyre intent separation implemented.
+  - Added preset field `TyreStopExpected` with compatibility resolution from legacy `TireChangeTimeSec` (`>0 => true`, `==0 => false`, missing/invalid => `true`).
+  - Preset apply no longer overwrites Strategy `TireChangeTime` slider seconds; apply now sets tyre intent only.
+  - Strategy stop calculations now gate tyre time through `EffectiveStrategyTyreTimeSeconds` (`TyresExpected ? TireChangeTime : 0`).
+  - Main Strategy UI adds `TYRES EXPECTED` toggle; Preset Manager now edits tyre intent instead of preset tyre seconds.
+  - Live pit prediction seams (`Fuel.Live.TireChangeTime_S`, `Fuel.Live.TotalStopLoss`, boxed-service model) intentionally unchanged.
+
 - 2026-05-18: Property Snapshot rolling recording indicator visual polish landed.
   - Debug UI now shows rolling status in a bordered state pill beside rolling controls using existing resolver output (`OFF`/`READY`/`RECORDING`) with explicit visual emphasis (`OFF` neutral grey, `READY` cyan/blue standby, `RECORDING` bright green active).
   - Added status-driven button enablement polish in-plugin only: `START` disabled during `RECORDING`; `STOP` disabled when inactive.

--- a/Docs/Internal/Plugin_UI_Tooltips.md
+++ b/Docs/Internal/Plugin_UI_Tooltips.md
@@ -245,3 +245,9 @@ Branch: work
 - `Updates` section shows installed version, latest release tag, status (`Up to date`/`Update available`/`Unable to check`), and `Check Now`/`Open Releases` actions.
 - `Dashboard Previews` section now provides placeholder cards with exact expected file paths (`Assets/Overview/*.png`) so preview images can be dropped in later without layout changes.
 - `Help / Notes` section contains concise driver reminders for touch vs bindings, Next/Previous screen behavior, Primary Dash Mode manual-recovery usage, and optional `TractionLoss` export setup.
+
+
+### Strategy tyre intent separation (May 2026)
+- Strategy tab: `TYRES EXPECTED` toggle tooltip explains planner intent gate (ON includes tyre service, OFF uses 0s).
+- Strategy tab: `TYRE TIME (s)` slider tooltip explains profile-seeded/manual what-if timing ownership.
+- Preset Manager: `Tyres Expected` tooltip explains preset intent-only ownership and that tyre seconds are no longer preset-owned.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,10 @@
+
+- 2026-05-19 Strategy tyre intent separation landed:
+  - Presets now own tyre-stop intent (`TyreStopExpected`) rather than tyre timing seconds.
+  - Strategy apply/reapply no longer mutates planner tyre slider seconds from preset legacy timing fields.
+  - Strategy stop math now uses intent-gated effective tyre time (`OFF=0s`, `ON=slider`).
+  - Live pit prediction/export seams remain unchanged (`Fuel.Live.TireChangeTime_S`, `Fuel.Live.TotalStopLoss`).
+
 - 2026-05-18: Property Snapshot rolling recording visual indicator polish validated.
   - Debug Options > Property Snapshot now renders rolling status as a bordered pill beside rolling controls using existing status resolver values (`OFF`/`READY`/`RECORDING`) with distinct emphasis states (grey/blue/green) for immediate in-plugin visibility.
   - Rolling controls now reflect status state in UI: `START` disables while `RECORDING`; `STOP` disables while inactive (`OFF`/`READY`).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,4 +1,9 @@
 
+- 2026-05-19 PR #745 review follow-up validated:
+  - Preset edit/clone/copy now hydrate/save explicit tyre intent from resolved compatibility state (`ResolvedTyreStopExpected`) instead of nullable raw field.
+  - Legacy preset open/save behavior now deterministic in Preset Manager; strategy/live seams unchanged.
+
+
 - 2026-05-19 Strategy tyre intent separation landed:
   - Presets now own tyre-stop intent (`TyreStopExpected`) rather than tyre timing seconds.
   - Strategy apply/reapply no longer mutates planner tyre slider seconds from preset legacy timing fields.

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -186,3 +186,10 @@ If Strategy looks repeatedly wrong, the usual causes are:
 - Refresh Calcs now recomputes calculated strategy outputs/stints from current effective inputs only; it does not reload profile/live data, reapply presets, or change owner/source selections.
 
 - Owner mode and effective basis are now treated separately in planner internals: owner radios (`Preset`/`Lap`/`Time`/`Live Detect`) select authority, while strategy calculations, preset dirty state, and preset serialization use the resolved effective race basis.
+
+
+## 12. Tyre-stop intent ownership (May 2026)
+- Presets now own only **Tyres Expected** intent (whether planned stops include tyre service).
+- Tyre timing seconds are not preset-owned; they come from profile-seeded Strategy tyre slider and can be manually overridden for what-if planning.
+- Strategy stop math gates tyre time with Tyres Expected (OFF = 0s, ON = slider value).
+- Live pit prediction/export seams remain unchanged in this Strategy task.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -62,6 +62,8 @@ These are **authoritative** once set by the user:
   - The Strategy tab keeps the inline preset combo as the active apply/select control.
   - The adjacent `Presets...` button opens the modal Preset Manager for create/rename/delete/edit/save-current flows without introducing a second preset-editing path.
   - Preset load/open paths now defensively skip null preset entries before binding the modal editor so malformed persisted rows do not hard-fail the popup open flow.
+- **Preset tyre intent ownership:** presets now store `TyreStopExpected` intent only (include tyres vs no tyres in planned stop math). Presets no longer own tyre timing seconds.
+- **Strategy tyre timing ownership:** `TireChangeTime` stays profile/strategy-slider owned; planner uses `EffectiveStrategyTyreTimeSeconds = StrategyTyresExpected ? TireChangeTime : 0` for strategy calculations only.
 
 ### Track-scoped planner persistence
 These planner inputs persist on the selected `TrackStats` record rather than on the car profile:

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -893,9 +893,8 @@ namespace LaunchPlugin
 
         SelectedPreRaceMode = NormalizePitStrategyValue(p.PreRaceMode);
 
-        // Tyre change time: only when specified
-        if (p.TireChangeTimeSec.HasValue)
-            TireChangeTime = p.TireChangeTimeSec.Value;
+        // Preset tyre intent only: no preset ownership of tyre timing seconds.
+        StrategyTyresExpected = p.ResolvedTyreStopExpected;
 
         // Max fuel override: only when specified
         if (SelectedPlanningSourceMode == PlanningSourceMode.Profile)
@@ -970,8 +969,7 @@ namespace LaunchPlugin
             : (_appliedPreset.RaceLaps ?? 0.0);
         bool durDiff = !hasEffectiveBasis || Math.Abs(appliedLength - effectiveLength) > 0.05;
 
-        bool tyreDiff = _appliedPreset.TireChangeTimeSec.HasValue &&
-                        Math.Abs(_appliedPreset.TireChangeTimeSec.Value - TireChangeTime) > 0.05;
+        bool tyreIntentDiff = _appliedPreset.ResolvedTyreStopExpected != StrategyTyresExpected;
 
         var appliedMaxFuel = SelectedPlanningSourceMode == PlanningSourceMode.Profile
             ? GetPresetMaxFuelOverrideLitres(_appliedPreset)
@@ -984,7 +982,7 @@ namespace LaunchPlugin
             (_appliedPreset.ContingencyInLaps != IsContingencyInLaps) ||
             Math.Abs(_appliedPreset.ContingencyValue - ContingencyValue) > 0.05;
 
-        return typeDiff || durDiff || tyreDiff || fuelDiff || contDiff;
+        return typeDiff || durDiff || tyreIntentDiff || fuelDiff || contDiff;
     }
 
     private void RaisePresetStateChanged()
@@ -2232,6 +2230,26 @@ namespace LaunchPlugin
         }
     }
 
+    private bool _strategyTyresExpected = true;
+    public bool StrategyTyresExpected
+    {
+        get => _strategyTyresExpected;
+        set
+        {
+            if (_strategyTyresExpected != value)
+            {
+                _strategyTyresExpected = value;
+                OnPropertyChanged(nameof(StrategyTyresExpected));
+                OnPropertyChanged(nameof(EffectiveStrategyTyreTimeSeconds));
+                RequestStrategyRecalc();
+                RaisePresetStateChanged();
+                MarkPlannerDirty();
+            }
+        }
+    }
+
+    public double EffectiveStrategyTyreTimeSeconds => StrategyTyresExpected ? TireChangeTime : 0.0;
+
     public double TireChangeTime
     {
         get => _tireChangeTime;
@@ -2241,6 +2259,7 @@ namespace LaunchPlugin
             {
                 _tireChangeTime = value;
                 OnPropertyChanged("TireChangeTime");
+                OnPropertyChanged(nameof(EffectiveStrategyTyreTimeSeconds));
                 OnPropertyChanged(nameof(TimingParameters));
                 RequestStrategyRecalc();
                 RaisePresetStateChanged();
@@ -2953,6 +2972,7 @@ namespace LaunchPlugin
         target.RaceMinutes = source.RaceMinutes;
         target.RaceLaps = source.RaceLaps;
         target.PreRaceMode = NormalizePitStrategyValue(source.PreRaceMode);
+        target.TyreStopExpected = source.TyreStopExpected;
         target.TireChangeTimeSec = source.TireChangeTimeSec;
         target.MaxFuelPercent = source.MaxFuelPercent;
         target.LegacyMaxFuelLitres = source.LegacyMaxFuelLitres;
@@ -2971,6 +2991,7 @@ namespace LaunchPlugin
             RaceMinutes = source.RaceMinutes,
             RaceLaps = source.RaceLaps,
             PreRaceMode = NormalizePitStrategyValue(source.PreRaceMode),
+            TyreStopExpected = source.TyreStopExpected,
             TireChangeTimeSec = source.TireChangeTimeSec,
             MaxFuelPercent = source.MaxFuelPercent,
             LegacyMaxFuelLitres = source.LegacyMaxFuelLitres,
@@ -3099,7 +3120,7 @@ namespace LaunchPlugin
             RaceLaps = isTimeLimitedEffective ? null : (int?)roundedLength,
 
             PreRaceMode = NormalizePitStrategyValue(SelectedPreRaceMode),
-            TireChangeTimeSec = TireChangeTime,
+            TyreStopExpected = StrategyTyresExpected,
             MaxFuelPercent = ConvertMaxFuelOverrideToPercent(MaxFuelOverride),
             LegacyMaxFuelLitres = null,
 
@@ -3117,7 +3138,7 @@ namespace LaunchPlugin
             RaceLaps = null,
             RaceMinutes = 40,
             PreRaceMode = (int)PreRaceMode.SingleStop,
-            TireChangeTimeSec = 23,
+            TyreStopExpected = true,
             MaxFuelPercent = 100,
             LegacyMaxFuelLitres = null,
             ContingencyInLaps = true,
@@ -4857,7 +4878,7 @@ namespace LaunchPlugin
                 {
                     num9++;
                     num8 = num7;
-                    double num12 = (double)num7 * (num + TireChangeTime);
+                    double num12 = (double)num7 * (num + EffectiveStrategyTyreTimeSeconds);
                     double num13 = num11 - num12;
                     if (num13 < 0.0)
                     {
@@ -5195,17 +5216,17 @@ namespace LaunchPlugin
 
             // Calculate pit stop time for this specific stop
             double refuelTime = ComputeRefuelSeconds(fuelToAdd);
-            double stationaryTime = Math.Max(this.TireChangeTime, refuelTime);
-            double totalStopTime = pitLaneTimeLoss + Math.Max(this.TireChangeTime, refuelTime);
-            // ... STOP line (now using BuildStopSuffix(this.TireChangeTime, refuelTime)) ...
+            double stationaryTime = Math.Max(this.EffectiveStrategyTyreTimeSeconds, refuelTime);
+            double totalStopTime = pitLaneTimeLoss + Math.Max(this.EffectiveStrategyTyreTimeSeconds, refuelTime);
+            // ... STOP line (now using BuildStopSuffix(this.EffectiveStrategyTyreTimeSeconds, refuelTime)) ...
             if (i == 1) { result.FirstStopTimeLoss = totalStopTime; }
             totalPitTime += totalStopTime;
 
             // STOP line (one line, hh:mm:ss total + components) + clear suffix
             var stopTs = TimeSpan.FromSeconds(totalStopTime);
             body.AppendLine();
-            string stopSuffix = BuildStopSuffix(this.TireChangeTime, refuelTime);
-            body.AppendLine($"STOP {i}:   Est {totalStopTime:F1}s   Lane {pitLaneTimeLoss:F1}s   Tyres {this.TireChangeTime:F1}s   Fuel {refuelTime:F1}s  {stopSuffix}");
+            string stopSuffix = BuildStopSuffix(this.EffectiveStrategyTyreTimeSeconds, refuelTime);
+            body.AppendLine($"STOP {i}:   Est {totalStopTime:F1}s   Lane {pitLaneTimeLoss:F1}s   Tyres {this.EffectiveStrategyTyreTimeSeconds:F1}s   Fuel {refuelTime:F1}s  {stopSuffix}");
             body.AppendLine();
 
             // Next stint length in laps — robustly clamped to [0, lapsRemaining]

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2972,7 +2972,7 @@ namespace LaunchPlugin
         target.RaceMinutes = source.RaceMinutes;
         target.RaceLaps = source.RaceLaps;
         target.PreRaceMode = NormalizePitStrategyValue(source.PreRaceMode);
-        target.TyreStopExpected = source.TyreStopExpected;
+        target.TyreStopExpected = source.ResolvedTyreStopExpected;
         target.TireChangeTimeSec = source.TireChangeTimeSec;
         target.MaxFuelPercent = source.MaxFuelPercent;
         target.LegacyMaxFuelLitres = source.LegacyMaxFuelLitres;
@@ -2991,7 +2991,7 @@ namespace LaunchPlugin
             RaceMinutes = source.RaceMinutes,
             RaceLaps = source.RaceLaps,
             PreRaceMode = NormalizePitStrategyValue(source.PreRaceMode),
-            TyreStopExpected = source.TyreStopExpected,
+            TyreStopExpected = source.ResolvedTyreStopExpected,
             TireChangeTimeSec = source.TireChangeTimeSec,
             MaxFuelPercent = source.MaxFuelPercent,
             LegacyMaxFuelLitres = source.LegacyMaxFuelLitres,

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -625,14 +625,19 @@
                             </ui:TitledSlider.ToolTip>
                         </ui:TitledSlider>
 
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <TextBlock Text="TYRES EXPECTED:" VerticalAlignment="Center" Margin="0,0,10,0" ToolTip="When ON, planned strategy stops include tyre service time. When OFF, planned strategy tyre time is 0s."/>
+                            <CheckBox IsChecked="{Binding StrategyTyresExpected, Mode=TwoWay}" VerticalAlignment="Center" ToolTip="Preset controls this intent. Tyre time seconds remain profile/strategy-slider owned."/>
+                        </StackPanel>
+
                         <ui:TitledSlider
-                            Title="Tyre Change Time (s): [Default is 22s]"
+                            Title="TYRE TIME (s): [Profile default 22s]"
                             Minimum="0" Maximum="60"
                             Value="{Binding TireChangeTime, Mode=TwoWay}">
                             <ui:TitledSlider.ToolTip>
                                 <ToolTip>
-                                    <TextBlock Text="Additional stationary time if tyres are changed. Set to 0s for a drive-through-only stop."
-                                        TextWrapping="Wrap" Width="260"/>
+                                    <TextBlock Text="Planner tyre-time input used when Tyres Expected is ON. This slider is seeded from profile tyre time and can be overridden for what-if planning."
+                                        TextWrapping="Wrap" Width="300"/>
                                 </ToolTip>
                             </ui:TitledSlider.ToolTip>
                         </ui:TitledSlider>

--- a/PresetsManagerView.xaml
+++ b/PresetsManagerView.xaml
@@ -275,11 +275,12 @@
                         </ComboBox>
                     </StackPanel>
 
-                    <!-- Tyre Change Time (s) -->
-                    <ui:TitledSlider Title="Tyre Change Time (s):"
-                           Minimum="0" Maximum="60"
-                           Value="{Binding TireChangeTimeSec, Mode=TwoWay}"
-                           ToolTip="Additional stop time when changing tyres (sec)."/>
+                    <StackPanel Orientation="Horizontal" Margin="0,10,0,8">
+                        <TextBlock Text="Tyres Expected:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                   ToolTip="Preset intent only. ON includes tyre service in planned strategy stops; OFF excludes tyre service time."/>
+                        <CheckBox IsChecked="{Binding TyreStopExpected, Mode=TwoWay}" VerticalAlignment="Center"
+                                  ToolTip="Preset no longer owns tyre timing seconds. Actual tyre-time value comes from profile/Strategy slider."/>
+                    </StackPanel>
 
                     <!-- Max Fuel Override (percent) -->
                     <ui:TitledSlider Title="Max Fuel Override (% of max tank):"

--- a/RacePreset.cs
+++ b/RacePreset.cs
@@ -46,7 +46,35 @@ namespace LaunchPlugin
             set { PreRaceMode = value ? 1 : 2; }
         }
 
-        // Tyre change time (seconds). null => leave current UI value unchanged.
+        // Preset tyre-stop intent. null => resolve from legacy TireChangeTimeSec compatibility rules.
+        public bool? TyreStopExpected { get; set; }
+
+        // Tyre-stop intent resolver (compatibility):
+        // - explicit TyreStopExpected when present
+        // - legacy TireChangeTimeSec > 0 => true
+        // - legacy TireChangeTimeSec == 0 => false
+        // - missing/invalid legacy => true
+        [JsonIgnore]
+        public bool ResolvedTyreStopExpected
+        {
+            get
+            {
+                if (TyreStopExpected.HasValue) return TyreStopExpected.Value;
+                if (TireChangeTimeSec.HasValue)
+                {
+                    double legacy = TireChangeTimeSec.Value;
+                    if (!double.IsNaN(legacy) && !double.IsInfinity(legacy))
+                    {
+                        if (legacy > 0.0) return true;
+                        if (legacy == 0.0) return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        // Legacy preset tyre timing field retained for backward compatibility read/write.
+        // Preset intent now lives in TyreStopExpected.
         public double? TireChangeTimeSec { get; set; }
 
         // Max fuel override (% of base tank). null => leave current UI value unchanged.


### PR DESCRIPTION
### Motivation
- Make presets own only the intent to include tyre service in planned stops while leaving tyre timing seconds under profile/strategy slider control.
- Prevent preset application from overwriting user/profile `TireChangeTime` slider values and support what-if planning without mutating stored timing.
- Preserve existing live pit prediction/export seams and backward compatibility with legacy preset fields.

### Description
- Introduced `TyreStopExpected` on `RacePreset` with a compatibility resolver `ResolvedTyreStopExpected` that maps legacy `TireChangeTimeSec` (`>0 => true`, `==0 => false`, missing/invalid => `true`).
- Reworked preset application and detection so `ApplyPresetValues` and `IsPresetModified` use preset tyre intent (`ResolvedTyreStopExpected`) and no longer set or compare `TireChangeTime` from presets.
- Added planner-side `StrategyTyresExpected` property and `EffectiveStrategyTyreTimeSeconds` (`StrategyTyresExpected ? TireChangeTime : 0.0`) and switched fuel/stop math to use the effective gated tyre time everywhere in `FuelCalcs`.
- Updated UI and preset editor XAML: added a `TYRES EXPECTED` toggle to the Strategy tab and replaced preset tyre-second editing with a `Tyres Expected` checkbox in the Preset Manager, plus updated tooltips and docs across `Docs/*` to reflect the new intent separation.

### Testing
- Built the solution and ran the existing automated unit/integration test suite; all tests completed successfully.
- Verified compile-time usage by running planner calculations that exercise stop-time math to ensure `EffectiveStrategyTyreTimeSeconds` is used in place of raw preset timing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5b615574832fa07151dfc6aba267)