### PR TITLE
Docs: Add Property Snapshot debug workflow and release-readiness documentation sweep

### DIFF
--- a/Docs/Dashboards.md
+++ b/Docs/Dashboards.md
@@ -1,5 +1,8 @@
 # Dashboards
 
+> **Ownership reminder:** dashboards own presentation. Plugin/subsystems own logic, exports, and race calculations.
+
+
 This page is the main driver-facing guide to the Lala dashboard package.
 
 ## 1. Overview

--- a/Docs/Fuel_Model.md
+++ b/Docs/Fuel_Model.md
@@ -67,6 +67,8 @@ If fuel values look wrong once, keep driving and let the session develop. If the
 4. Relearn only the affected value or condition if needed.
 5. Lock again only after the data has clearly settled.
 
+For debug workflows (manual snapshot, rolling capture, replay triage), use `Docs/Internal/Property_Snapshot_Debug_Workflow.md`.
+
 ## 8. Practical guidance
 
 - Expect the model to become better over several clean laps, not one.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,10 @@
+- 2026-05-20: Documentation sweep (release-readiness) completed; documentation-only.
+  - Added `Docs/Internal/Property_Snapshot_Debug_Workflow.md` as canonical internal workflow for Property Snapshot manual/rolling/replay usage, troubleshooting matrix, and escalation flow.
+  - Updated `Docs/Project_Index.md` with topic owner matrix, terminology matrix, and release-history ownership rubric.
+  - Clarified user-doc boundaries for Strategy vs runtime fuel authority and PreRace info-layer semantics.
+  - Added compact Race End / Finish Lifecycle clarification in existing subsystem docs; no standalone RaceFinish subsystem doc introduced.
+  - No runtime code/XAML/dashboard/settings/export/log-string changes.
+
 - 2026-05-20: Strategy Save All target-ownership fix validated (planner-selected profile/track).
   - Fixed `FuelCalcs.SavePlannerDataToProfile()` to always persist Save All into the Strategy planner-selected target (`SelectedCarProfile` + `SelectedTrackStats/SelectedTrack`) instead of switching to live-session `ActiveProfile`/`CurrentTrackKey` when live telemetry is active.
   - Confirmation dialog now reliably reports the actual planner-selected profile/track saved by this path.

--- a/Docs/Internal/Property_Snapshot_Debug_Workflow.md
+++ b/Docs/Internal/Property_Snapshot_Debug_Workflow.md
@@ -1,0 +1,121 @@
+# Property Snapshot Debug Workflow (Internal)
+
+Validated against commit: HEAD
+Last updated: 2026-05-20
+Branch: work
+
+## Purpose and ownership
+This page is the **canonical internal workflow guide** for Property Snapshot debugging operations:
+- manual snapshot workflow,
+- rolling capture workflow,
+- replay workflow,
+- snapshot group usage guidance,
+- troubleshooting decision matrix,
+- escalation workflow.
+
+This page is **not** the canonical owner for:
+- export/property definitions (see `Docs/Internal/SimHubParameterInventory.md`),
+- log-message contracts/tags (see `Docs/Internal/SimHubLogMessages.md`).
+
+## Manual vs Rolling capture
+
+### Manual capture (one-shot)
+Use manual capture when you need a precise moment sample (for example: pit-entry edge, finish-latch edge, or a specific Strategy transition).
+
+Recommended pattern:
+1. Enable required debug toggles in plugin settings.
+2. Select only the snapshot groups relevant to the issue.
+3. Trigger the marker/capture at the event of interest.
+4. Save the one-shot file and annotate session context (track/car/session type/replay or live).
+
+Use manual capture when:
+- issue is event-edge specific,
+- you need low-noise evidence,
+- you are validating one state transition.
+
+### Rolling capture
+Use rolling capture when you need state evolution across time/laps.
+
+Rolling modes:
+- **MANUAL**: rolling file present, writes driven by explicit trigger workflow.
+- **FREQUENCY**: time-based captures.
+- **PER LAP**: one capture per completed lap (deduplicated by lap index).
+
+Guidance:
+- prefer **PER LAP** for strategy/fuel stability issues,
+- prefer **FREQUENCY** for rapid state transitions,
+- keep enabled groups narrow to reduce noisy rows.
+
+### CSV expectations
+- Rolling CSV is a wide, evolving debug artifact for timeline analysis.
+- One-shot snapshots remain best for event-edge forensic checks.
+- Treat CSV as **debug evidence**, not a runtime contract source.
+- Export meaning/source-of-truth stays in Parameter Inventory.
+
+## Replay workflow
+Replay is valid for many diagnostics, but some signals can differ from live timing/hydration behavior.
+
+Recommended replay workflow:
+1. Identify issue category first (fuel/strategy/pitexit/finish/league/dash).
+2. Run a short replay window around the anomaly.
+3. Capture one-shot snapshots at anomaly edge and one rolling sequence around it.
+4. Cross-check with canonical logs by tag.
+5. Confirm whether behavior reproduces in live session.
+
+Replay caveats:
+- session transitions and hydration gaps can look different than live,
+- finish lifecycle and end-phase edges may tick differently,
+- do not promote replay-only artifacts to runtime truth without live corroboration.
+
+## Property Snapshot group usage
+Use groups to limit noise and preserve ownership boundaries.
+
+- **Fuel/Strategy**: runtime fuel, strategy basis, pre-race planning deltas.
+- **Car/Opp/H2H**: race context, opponents, pit-exit cohort/position surfaces, class context.
+- **Pit/PitExit**: pit control, pit timing, entry/exit trip surfaces.
+- **Shift Assist**: shift cues and related assist-state surfaces.
+- **Message System**: message engine outputs and queue surfaces.
+- **League Class**: effective class resolver outputs and class-facing publication seams.
+- **Raw Debug**: everything else that is intentionally uncategorized.
+
+Group membership behavior is implementation-owned; this page defines operational usage only.
+
+## Troubleshooting decision matrix
+| Issue type | Primary tool | Snapshot groups | Key exports (examples) | Key logs | Replay caveats | Escalation path |
+|---|---|---|---|---|---|---|
+| Fuel runtime mismatch | Rolling + one-shot at lap edge | Fuel/Strategy | `Fuel.*`, `Fuel.Refuel.*`, `Fuel.Delta.*`, `Fuel.Contingency.*` | `[LalaPlugin:Fuel Burn]`, `[LalaPlugin:FUEL PER LAP]` | Early-lap confidence and replay hydration can mask live authority transitions | Validate in live session; then compare with Strategy subsystem assumptions |
+| Strategy mismatch | One-shot + PER LAP rolling | Fuel/Strategy | `StrategyDash.*`, `LalaLaunch.PreRace.*`, planner-facing fuel basis exports | `[LalaPlugin:Strategy]`, `[LalaPlugin:Leader Lap]` | Live Detect/session metadata may resolve differently in replay windows | Confirm selected planner owner/source before escalation |
+| PreRace discrepancy | One-shot pre-grid + at green transition | Fuel/Strategy | `LalaLaunch.PreRace.*`, `StrategyDash.*` | `[LalaPlugin:Strategy]` and fuel basis logs | Pre-green vs race-running authority seam differs by design | Escalate with exact phase (`SessionState`) evidence |
+| PitExit issue | Rolling around pit-in/out + one-shot at both edges | Car/Opp/H2H + Pit/PitExit + League Class | `PitExit.*`, class-position/context exports | `[LalaPlugin:PitExit]`, `[LalaPlugin:Opponents]` | Replay may alter opponent row availability timing | Include league mode state + pit-loss source in escalation |
+| League issue | One-shot at resolver transition + short rolling sequence | League Class + Car/Opp/H2H | League/effective-class exports and class-facing fields | League and class-resolution logs in canonical log doc | Replay may show transient unresolved identity rows | Provide league definition + fallback state in escalation note |
+| RaceFinish issue | One-shot at finish-latch + rolling through end-phase | Car/Opp/H2H + Fuel/Strategy | `RaceFinish.*`, `Race.EndPhase.*`, related race-state exports | `[LalaPlugin:Finish]`, RaceDenom diagnostics | Finish lifecycle ticks can differ in replay and post-race churn | Corroborate with live reproduction when possible |
+| Dash visibility issue | One-shot with control state + matching log window | Fuel/Strategy and/or relevant feature group | Dash-facing state exports and visibility mode fields | `[LalaPlugin:Dash]`, `[LalaPlugin:PitScreen]` | Replay may not mirror real input cadence | Verify dashboard expression uses plugin-owned exports only |
+| Replay anomaly | Combined one-shot + rolling + log timeline | Narrow to affected subsystem groups | Issue-specific canonical exports only | Issue-specific canonical logs | Replay-only anomalies can be false positives | Mark as replay-only until live verified |
+| Property Snapshot issue | Snapshot controls + rolling CSV checks | Raw Debug + affected subsystem groups | `Debug.PropertySnapshot.*` + affected family | Property snapshot debug logs | Replay itself usually not primary cause | Escalate with control-state + mode + schema/reset context |
+
+## Common log usage flow
+1. Filter logs by subsystem tag first.
+2. Pair log timestamps with snapshot rows.
+3. Confirm active authority/source from exports.
+4. Only then infer behavior correctness.
+
+Canonical log tag details remain in `Docs/Internal/SimHubLogMessages.md`.
+
+## Escalation workflow
+When opening an internal debugging escalation, include:
+- issue category,
+- live vs replay,
+- selected snapshot groups,
+- one-shot file(s) and rolling interval,
+- key log excerpt tags,
+- expected behavior vs observed behavior,
+- whether repro is deterministic.
+
+## Race end / finish lifecycle note
+RaceFinish remains distributed ownership by design:
+- export contract: `SimHubParameterInventory` (`RaceFinish.*`, `Race.EndPhase.*`),
+- observability contract: `SimHubLogMessages` (finish diagnostics, RaceDenom/lifecycle tags),
+- validation history: `RepoStatus` and `Development_Changelog`,
+- subsystem context: lifecycle explanation in existing subsystem docs.
+
+No standalone `Docs/Subsystems/RaceFinish.md` is introduced in this sweep.

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -10,6 +10,8 @@ Branch: work
 Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub.Logging.Current.Warn(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
 
 ## How to read logs for debugging
+Workflow routing note: `Docs/Internal/Property_Snapshot_Debug_Workflow.md` owns debugging workflow/triage guidance; this page remains the canonical log-message/tag contract.
+
 - **Filter by tag prefix** (e.g., `[LalaPlugin:Fuel Burn]`, `[LalaPlugin:Pit Cycle]`, `[LalaPlugin:Finish]`) to isolate subsystems.
 - **Lap-coupled logs** (PACE/FUEL/RACE PROJECTION) appear once per completed lap and include acceptance reasons; correlate them with lap numbers.
 - **Pit-cycle logs** appear on pit entry/exit/out-lap completion. Use them with PitLite status exports.

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -73,6 +73,36 @@ These pages support maintainers, support work, and Codex tasks. They are not par
 - [Internal/Code_Snapshot.md](Internal/Code_Snapshot.md)
 - [Internal/Release_Checklist.md](Internal/Release_Checklist.md)
 - [Internal/Development_Changelog.md](Internal/Development_Changelog.md)
+- [Internal/Property_Snapshot_Debug_Workflow.md](Internal/Property_Snapshot_Debug_Workflow.md)
+
+
+## Topic owner matrix
+| Topic | Canonical owner doc |
+|---|---|
+| Runtime Fuel System | `Docs/Subsystems/Fuel_Model.md` |
+| Strategy planner behavior | `Docs/Subsystems/Fuel_Planner_Tab.md` |
+| User-facing fuel trust workflow | `Docs/Fuel_Model.md` |
+| Dash integration contract | `Docs/Subsystems/Dash_Integration.md` |
+| Dashboard user workflow | `Docs/Dashboards.md` |
+| Race end / finish lifecycle contract | `Docs/Internal/SimHubParameterInventory.md` (`RaceFinish.*`, `Race.EndPhase.*`) + `Docs/Internal/SimHubLogMessages.md` |
+| Property Snapshot debug workflow | `Docs/Internal/Property_Snapshot_Debug_Workflow.md` |
+
+## Terminology matrix
+| User term | Technical term | Canonical owner |
+|---|---|---|
+| Strategy | Fuel Planner / Strategy Tab | `Docs/Subsystems/Fuel_Planner_Tab.md` |
+| Fuel Model | Runtime Fuel System | `Docs/Subsystems/Fuel_Model.md` |
+| Pit Assist | Pit Entry + Pit Timing + Pit Commands/Fuel Control | `Docs/Subsystems/Pit_Entry_Assist.md`, `Docs/Subsystems/Pit_Timing_And_PitLoss.md`, `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md` |
+| Dashboards | Dash Integration contract + dashboard package usage | `Docs/Subsystems/Dash_Integration.md` + `Docs/Dashboards.md` |
+| RaceFinish | Finish lifecycle / end-phase contract | `Docs/Internal/SimHubParameterInventory.md` + `Docs/Internal/SimHubLogMessages.md` |
+| League Class | Resolver system / effective class publication | `Docs/Subsystems/League_Class_System.md` |
+| Property Snapshot | Internal observability workflow | `Docs/Internal/Property_Snapshot_Debug_Workflow.md` |
+
+## Release-history ownership rubric
+- `README.md` = stable product overview and doc entry links.
+- `CHANGELOG.md` = public release notes.
+- `Docs/RepoStatus.md` = current validated repository truth.
+- `Docs/Internal/Development_Changelog.md` = internal implementation history between releases.
 
 ## v1 documentation notes
 - `README.md` is the public landing page.

--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -148,3 +148,9 @@ That applies especially to:
 - [Launch System](Launch_System.md) for launch setup and review
 - [Rejoin Assist](Rejoin_Assist.md) and [Pit Assist](Pit_Assist.md) for driver aids
 - [H2H System](H2H_System.md) for race-context comparisons
+
+
+## Runtime vs Strategy boundary (release-readiness note)
+- **Strategy tab** is the driver planning surface.
+- **Fuel runtime** remains the live race authority for runtime fuel exports and pit guidance.
+- **PreRace** is an info layer and does not replace runtime race-running guidance during green-flag running.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,10 @@
+- 2026-05-20: Documentation sweep for release readiness completed (documentation-only).
+  - Added canonical internal workflow doc `Docs/Internal/Property_Snapshot_Debug_Workflow.md` for manual/rolling/replay snapshot operations, troubleshooting matrix, and escalation guidance.
+  - Clarified Project Index topic ownership, terminology mapping, and release-history ownership rubric.
+  - Clarified Fuel/Strategy/PreRace/runtime boundaries across user docs and subsystem references.
+  - RaceFinish ownership explicitly kept distributed (no new `Docs/Subsystems/RaceFinish.md`).
+  - No runtime files, exports, Property Snapshot grouping, log strings, or behavior changed.
+
 - 2026-05-20: Strategy Save All ownership fix landed.
   - Strategy `Save All to Profile` now saves strictly to planner-selected `SelectedCarProfile` + selected planner track (`SelectedTrackStats`/selected track key), including when a different live session car/track is active.
   - Save path no longer retargets to live `ActiveProfile` / `CurrentTrackKey`; confirmation messaging now reflects the true planner-selected save target.

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -22,6 +22,10 @@ User-facing docs should treat this as **Strategy**. Older “Fuel Planner” wor
 
 ## 2. Strategy vs live observation
 
+### Runtime boundary (important)
+Strategy owns planner intent and pre-race guidance inputs. Runtime race-running fuel authority remains in plugin-owned runtime exports (`Fuel.*`, `Fuel.Refuel.*`, `Fuel.Delta.*`, `Fuel.RequiredBurnToEnd*`). Dashboards consume these exports and do not replace plugin calculations.
+
+
 The plugin keeps a deliberate split between:
 
 - the **live fuel and pace systems**, which observe the current session and build confidence, and

--- a/Docs/Subsystems/Pace_And_Projection.md
+++ b/Docs/Subsystems/Pace_And_Projection.md
@@ -175,3 +175,7 @@ Runtime-health handling is now expected to prefer targeted fuel/live-snapshot re
 
 ## v1 documentation note
 Use **Strategy** for the user-facing planning story, but keep **Pace & Projection** as the canonical runtime subsystem that feeds fuel math and stable live race-distance behavior.
+
+
+## Race End / Finish Lifecycle
+Race end/finish contract remains distributed by design: exports are owned by `Docs/Internal/SimHubParameterInventory.md` (`RaceFinish.*`, `Race.EndPhase.*`), observability is owned by `Docs/Internal/SimHubLogMessages.md`, and validated-change history belongs in `Docs/RepoStatus.md` and `Docs/Internal/Development_Changelog.md`. This subsystem references lifecycle behavior but is not the canonical contract owner for those internal finish exports/log tags.

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -208,3 +208,11 @@ For most drivers, this order works well:
 4. [Fuel Model](Fuel_Model.md)
 5. [Dashboards](Dashboards.md)
 6. Then the feature pages you use most: [Shift Assist](Shift_Assist.md), [Launch System](Launch_System.md), [Rejoin Assist](Rejoin_Assist.md), [Pit Assist](Pit_Assist.md), and [H2H System](H2H_System.md)
+
+
+## Documentation ownership quick reference
+- User workflow: this guide + feature pages in `Docs/`.
+- Technical behavior ownership: `Docs/Subsystems/*.md`.
+- Export contract owner: `Docs/Internal/SimHubParameterInventory.md`.
+- Log contract owner: `Docs/Internal/SimHubLogMessages.md`.
+- Property Snapshot workflow owner: `Docs/Internal/Property_Snapshot_Debug_Workflow.md`.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Version **1.0** documentation is now organized so GitHub readers can move from a
 
 ## Plugin vs Dashboard Responsibility
 
-The plugin owns the **learning, storage, calculations, and exports**. Dashboards are the presentation layer: they show those outputs and provide limited interaction, but they do not own strategy math, saved learning, H2H selection, or launch logic.
+The plugin owns the **learning, storage, calculations, and exports**. Dashboards are the presentation layer: they show those outputs and provide limited interaction, but they do not own strategy math, saved learning, H2H selection, launch logic, finish lifecycle math, or Property Snapshot grouping contracts.
 
 ## Dashboard Package
 
@@ -167,7 +167,7 @@ Presets are managed from **Strategy** through the **`Presets...`** modal flow. T
 
 ## Notes / Important Boundaries
 
-- **PreRace** is display-only. It does not replace the planner or change the live fuel model.
+- **PreRace** is display-only. It does not replace Strategy calculations and does not change live runtime fuel ownership (`Fuel.*`, `Fuel.Refuel.*`, `Fuel.Delta.*`).
 - **Live Snapshot** can auto-drive relevant planning values. When it is active, the corresponding manual controls are disabled.
 - Launch controls live under **Settings -> Launch Settings**. **Launch Analysis** remains the saved-run review tab.
 - The future/global message system is not documented here as an active user feature.


### PR DESCRIPTION
### Motivation
- Provide a canonical internal workflow for Property Snapshot debugging (manual, rolling, replay) to standardize triage and escalation.
- Clarify ownership boundaries between dashboards, Strategy, and runtime fuel to avoid user confusion about authoritative sources.
- Surface a topic-owner and terminology matrix to make documentation ownership and release-history responsibilities explicit.
- Record this documentation sweep in internal changelogs and repo status for release-readiness transparency.

### Description
- Added `Docs/Internal/Property_Snapshot_Debug_Workflow.md` containing manual/rolling/replay capture guidance, snapshot group usage, troubleshooting matrix, and escalation workflow.
- Updated multiple user and internal docs (`Docs/Dashboards.md`, `Docs/Fuel_Model.md`, `Docs/Quick_Start.md`, `Docs/Strategy_System.md`, `Docs/User_Guide.md`, `Docs/Subsystems/Pace_And_Projection.md`, `Docs/Internal/SimHubLogMessages.md`, `Docs/Project_Index.md`, `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`, `README.md`) to clarify runtime vs Strategy boundaries, finish lifecycle ownership, and to link the new debug-workflow doc.
- Extended `Docs/Project_Index.md` with a topic owner matrix, terminology matrix, and release-history ownership rubric, and added the new doc to the internal index.
- Updated internal changelog and repo status entries to record the documentation sweep and to state that no runtime code, exports, or log strings were changed.

### Testing
- Documentation build and internal link/index consistency checks were performed and completed successfully. 
- No runtime code or unit tests were required because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e264d0cdc832f97c544067a0c769f)