### PR TITLE
docs: Fuel Revamp Phase 3B — temporal semantics & lifecycle classification

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,5 +1,13 @@
 
 ## 2026-05-28 — Fuel Revamp Phase 3B temporal semantics/lifecycle classification (documentation-only)
+
+- 2026-05-28: PR #759 review-comment follow-up (documentation-only naming correction).
+  - Corrected Phase 3B temporal-semantics section export names to use actual SimHub properties:
+    - `Fuel.ProjectionLapTime_Stable` / `Fuel.ProjectionLapTime_StableSource` (instead of unqualified projection names),
+    - `LalaLaunch.PreRace.*` (instead of `PreRace.*`),
+    - `Fuel.Live.DriveTimeAfterZero` / `Fuel.Live.ProjectedDriveSecondsRemaining` (instead of unqualified names).
+  - No runtime code/behavior changes; documentation contract accuracy fix only.
+
 - Classification: **internal-only** (analysis + documentation alignment only).
 - Added explicit temporal semantics/lifecycle classification matrix for fuel/pit/prerace/strategydash/projection/finish export families in `Docs/Subsystems/Fuel_Model.md`.
 - Added direct answers for stable-vs-smoothed export usage (`LiveLapsRemainingInRace*`, `_S`, `_Stable_S`) and dashboard seam preferences.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,12 @@
+
+## 2026-05-28 — Fuel Revamp Phase 3B temporal semantics/lifecycle classification (documentation-only)
+- Classification: **internal-only** (analysis + documentation alignment only).
+- Added explicit temporal semantics/lifecycle classification matrix for fuel/pit/prerace/strategydash/projection/finish export families in `Docs/Subsystems/Fuel_Model.md`.
+- Added direct answers for stable-vs-smoothed export usage (`LiveLapsRemainingInRace*`, `_S`, `_Stable_S`) and dashboard seam preferences.
+- Added explicit future rationalisation candidate list and do-not-touch-yet export families.
+- Confirmed no runtime code, export names, calculations, or dashboard contracts changed; documentation clarifies current behavior only.
+- Property Snapshot list reviewed: yes (no export/property contract changes in this task).
+
 - 2026-05-27: Pit-window contingency-aware feasibility update completed.
   - Updated pit-window OPEN/status gating to include contingency on required side for PUSH/STD/ECO checks (`needAdd = lapsRemaining*burn + contingencyForMode - currentFuel`), preserving priority order `CLEAR PUSH > RACE PACE > FUEL SAVE > TANK SPACE`.
   - Litre contingency uses shared litres across checks; lap-based contingency resolves litres per burn basis (push/stable/save), aligned with existing contingency resolver semantics.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,15 @@
+# Repo Status
+
+Validated against commit: HEAD
+Last updated: 2026-05-28
+Branch: work
+
+## Current status
+- Documentation alignment update completed for Fuel Revamp Phase 3B temporal semantics/lifecycle classification (documentation-only).
+- Runtime behavior unchanged in this pass: no code edits, no export additions/removals/renames, no calculation changes.
+- Canonical seam split remains unchanged: `Fuel.Refuel.*` runtime tactical guidance vs `StrategyDash.*`/`PreRace.*` pre-green planning guidance.
+- Property Snapshot list reviewed: yes (no export/property behavior change required).
+
 - 2026-05-27: Pit window contingency-awareness alignment landed (runtime fuel status semantics).
   - Pit-window open feasibility (`CLEAR PUSH`/`RACE PACE`/`FUEL SAVE`) now evaluates contingency-aware required add by mode (`lapsRemaining*burn + contingencyForMode - currentFuel`) before tank-space fit checks.
   - Litre-configured contingency applies shared litres across modes; lap-configured contingency resolves litres per mode burn basis (push/stable/save).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,7 @@ Branch: work
 - Runtime behavior unchanged in this pass: no code edits, no export additions/removals/renames, no calculation changes.
 - Canonical seam split remains unchanged: `Fuel.Refuel.*` runtime tactical guidance vs `StrategyDash.*`/`PreRace.*` pre-green planning guidance.
 - Property Snapshot list reviewed: yes (no export/property behavior change required).
+- PR #759 review-comment follow-up completed: corrected documentation export names to canonical SimHub property names (`Fuel.ProjectionLapTime_Stable*`, `LalaLaunch.PreRace.*`, `Fuel.Live.DriveTimeAfterZero`, `Fuel.Live.ProjectedDriveSecondsRemaining`).
 
 - 2026-05-27: Pit window contingency-awareness alignment landed (runtime fuel status semantics).
   - Pit-window open feasibility (`CLEAR PUSH`/`RACE PACE`/`FUEL SAVE`) now evaluates contingency-aware required add by mode (`lapsRemaining*burn + contingencyForMode - currentFuel`) before tank-space fit checks.

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -268,3 +268,64 @@ Use **Strategy** terminology for GitHub-facing explanations. Treat older “Fuel
 
 - `LalaLaunch.PreRace.TotalFuelNeeded` now uses active contingency litres (`base race fuel + active contingency`) and no longer applies the legacy hardcoded `+2 laps` PreRace buffer.
 - Added additive `StrategyDash.*` pre-green advice seam; it does not replace runtime `Fuel.*`, `Fuel.Pit.*`, `Fuel.Delta.*`, `Fuel.RequiredBurnToEnd*`, or `Pit.FuelControl.*` ownership.
+
+
+## Fuel Revamp Phase 3B — Temporal semantics and lifecycle classification (analysis snapshot)
+
+This section documents current **as-implemented** temporal semantics without changing runtime behavior.
+
+### Canonical seam split (unchanged)
+- `Fuel.Refuel.*` = runtime next-stop tactical guidance seam (race-running authority).
+- `StrategyDash.*` + `LalaLaunch.PreRace.*` = pre-green/planning guidance seam.
+- These seams are intentionally separate and must not be merged.
+
+### Lifecycle map by family
+| Family / export group | Temporal type | Owner | Reset / invalidation trigger | Dash preference | Risk if changed |
+|---|---|---|---|---|---|
+| `Fuel.LiveFuelPerLap` | live/raw | Fuel Model | 500 ms poll; session/runtime reset; next valid sample | support/debug input; not primary UI value | medium |
+| `Fuel.LiveFuelPerLap_Stable` | stable-held | Fuel Model | 500 ms poll with deadband hold; reset on session/runtime reset | preferred fuel-burn seam | do not touch |
+| `Fuel.LiveFuelPerLap_StableSource`, `...StableConfidence` | provenance/source-label | Fuel Model | updates with stable authority transitions | debug/provenance + trust widgets | high |
+| `Fuel.LiveLapsRemainingInRace` | stable-held (runtime mirror) | Fuel Model + Pace & Projection input | 500 ms poll; projection invalidation/reset | use only if `_Stable` unavailable; otherwise treat as compatibility mirror | medium |
+| `Fuel.LiveLapsRemainingInRace_Stable` | stable-held | Fuel Model | 500 ms poll; reset/invalidation follows projection validity | preferred numeric laps-to-end seam | do not touch |
+| `Fuel.LiveLapsRemainingInRace_S`, `Fuel.LiveLapsRemainingInRace_Stable_S` | smoothed-display | Dashboard helper (Fuel model EMA state) | 500 ms poll EMA; reset when projection invalid or runtime reset | display-only widgets; do not use for control logic | high |
+| `Fuel.RequiredBurnToEnd*` | live/raw + debounced-state (state text/classification) | Fuel Model | 500 ms poll; invalid when basis missing | preferred tactical burn-to-end seam | do not touch |
+| `Fuel.Refuel.*` | live/raw + provenance labels + command-context mirrors (`DataMode`,`BurnMode`) | Fuel Model (with Pit Fuel Control DATA/SOURCE selector inputs) | 500 ms poll; invalid on missing basis/cap context; reset on runtime/session reset | preferred runtime next-stop seam | do not touch |
+| `Fuel.Delta.*` incl `AfterStop.Selected` | live/raw (selected seam includes source selection) | Fuel Model | 500 ms poll; selected variant follows SOURCE each tick | preferred tactical delta seams | high |
+| `Fuel.Contingency.*` | live/raw + provenance/source-label | Fuel Model (+ planner/profile fallback) | 500 ms poll; changes on planner/profile/manual contingency changes | preferred reserve visibility seam | high |
+| `Fuel.StintBurnTarget*`, `Fuel.FuelBurnPredictor*` | live/raw + helper-text/source labels | Fuel Model | 500 ms poll; reset on session/runtime reset | secondary guidance; useful on strategy pages | medium |
+| `Fuel.Pit.*` | mixed: live/raw + smoothed-display + latched (`Fuel.Pit.Box.*`) | Fuel Model + Pit Timing | 500 ms poll; box variants per-tick; box latches reset on deselect/box exit | runtime pit widgets should use these directly | do not touch |
+| `Pit.Box.*` | live/raw + frozen-for-stop target (`TargetSec`) | Pit Timing | per-tick in box; reset on box exit/session reset | preferred in-box lifecycle seam | do not touch |
+| `Fuel.Live.TireChangeCount`, `Fuel.Live.TireChangeTime_S`, `Fuel.Live.TotalStopLoss`, `Fuel.Live.PitLaneLoss_S`, `Pit.LastPaceDeltaNetLoss` | mixed: live/raw and smoothed-display | Pit Timing + Fuel Model consumer seams | per pit lifecycle / 500 ms poll; reset/session transitions | preferred pit prediction/perf seams | high |
+| `Fuel.Live.RemainingStints`, `Fuel.MaxTank` | live/raw | Fuel Model | 500 ms poll; cap seam invalidation/reset | preferred runtime capacity context | high |
+| `PreRace.*`, `StrategyDash.*`, `Fuel.Setup.*` | planner-deterministic + helper-text + session-static fallback (`Fuel.Setup.*`) | Strategy Planner + PreRace adapter | per-tick/500 ms; session phase transitions; live/setup availability | preferred pre-green seams only | do not use for race-running refuel widgets |
+| `ProjectionLapTime_Stable`, `...Source` | stable-held + provenance/source-label | Pace & Projection | 500 ms poll; deadband hold; reset on runtime/session reset | preferred projection seam | do not touch |
+| `LiveProjectedDriveTimeAfterZero`, `LiveProjectedDriveSecondsRemaining`, `Fuel.After0.*` | live/raw + held-through-gap fallback between planner/live after-zero | Pace & Projection + Fuel Model | 500 ms poll; timer-zero/lap-cross transitions; reset | support/runtime projection seams; not primary dash headline | medium |
+| `Race.EndPhase*`, `Race.LastLapLikely` | debounced-state | RaceFinish lifecycle | per-tick with confidence/debounce; session/lifecycle reset | preferred finish-phase seam | do not touch |
+| `RaceFinish.*` | frozen-post-event + staged latch (class snapshot then player snapshot) | RaceFinish lifecycle | latch on finish triggers; reset when leaving finish lifecycle/session reset | preferred post-finish widgets | do not touch |
+
+### Direct answers for Phase 3B questions
+1. Stable exports genuinely needed: `Fuel.LiveFuelPerLap_Stable`, `Fuel.LiveFuelPerLap_StableSource`, `Fuel.LiveFuelPerLap_StableConfidence`, `Fuel.LiveLapsRemainingInRace_Stable`, `ProjectionLapTime_Stable`, `ProjectionLapTime_StableSource`.
+2. `Fuel.LiveLapsRemainingInRace` is effectively already stable in current runtime flow, but should be treated as a compatibility mirror seam rather than the explicit contract anchor.
+3. `Fuel.LiveLapsRemainingInRace_Stable` adds explicit contract clarity/intent for dashboards/debug tools and isolates future rationalisation from the ambiguous non-suffixed name.
+4. `_Stable_S` adds EMA display smoothing only (visual anti-jitter), not new calculation authority.
+5. Dashboards should prefer `Fuel.LiveLapsRemainingInRace_Stable` for numeric logic, `_Stable_S` only for visual text/needle smoothing.
+6. `_S` display-smoothing families include `Fuel.LiveLapsRemainingInRace_S`, `Fuel.LiveLapsRemainingInRace_Stable_S`, plus other `_S` pit display exports (for example `Fuel.Pit.TotalNeededToEnd_S`, pit delta `_S` variants, `Fuel.Live.PitLaneLoss_S`, `Fuel.Live.TireChangeTime_S`).
+7. Latched/frozen/held/debounced examples:
+   - latched: `Fuel.Pit.Box.EntryFuel`, `Fuel.Pit.Box.WillAddLatched`, boxed stop target `Pit.Box.TargetSec`.
+   - frozen-post-event: `RaceFinish.*` snapshots.
+   - held-through-gap: stable fuel/projection source/value holds, after-zero planner/live handoff holds.
+   - debounced-state: pit-window state text transitions, `Race.EndPhase*` confidence staging.
+8. Preferred dashboard seams: runtime race work => `Fuel.Refuel.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Delta.*`, `Fuel.Contingency.*`, `Fuel.Pit.*`, `Pit.Box.*`, `ProjectionLapTime_Stable`, `Race.EndPhase*`, `RaceFinish.*`.
+9. Debug/provenance/internal-first seams: `...StableSource`, `...StableConfidence`, `Fuel.Refuel.BurnSource/LapSource/DataMode/BurnMode/SelectedBurnPerLap`, most explicit helper text fields.
+10. Future rationalisation candidates (not removal now): redundant mirror pairs around `LiveLapsRemainingInRace` vs `_Stable`, overlapping `_S` smoothing duplicates, helper/provenance naming consistency across fuel/projection families.
+
+### Do-not-touch-yet list (high coupling)
+- `Fuel.Refuel.*` runtime next-stop contract.
+- `Fuel.RequiredBurnToEnd*` state classification contract.
+- `Fuel.Delta.*` tactical contingency-protected semantics.
+- `Fuel.Pit.Box.*` latch lifecycle.
+- `Race.EndPhase*` and `RaceFinish.*` finish lifecycle exports.
+
+### Property Snapshot contract check
+- Property Snapshot list reviewed: **yes**.
+- Reason: this task documents semantics only and does not add/remove/rename/change behavior of any export/property, so snapshot group membership remains unchanged.

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -297,14 +297,14 @@ This section documents current **as-implemented** temporal semantics without cha
 | `Pit.Box.*` | live/raw + frozen-for-stop target (`TargetSec`) | Pit Timing | per-tick in box; reset on box exit/session reset | preferred in-box lifecycle seam | do not touch |
 | `Fuel.Live.TireChangeCount`, `Fuel.Live.TireChangeTime_S`, `Fuel.Live.TotalStopLoss`, `Fuel.Live.PitLaneLoss_S`, `Pit.LastPaceDeltaNetLoss` | mixed: live/raw and smoothed-display | Pit Timing + Fuel Model consumer seams | per pit lifecycle / 500 ms poll; reset/session transitions | preferred pit prediction/perf seams | high |
 | `Fuel.Live.RemainingStints`, `Fuel.MaxTank` | live/raw | Fuel Model | 500 ms poll; cap seam invalidation/reset | preferred runtime capacity context | high |
-| `PreRace.*`, `StrategyDash.*`, `Fuel.Setup.*` | planner-deterministic + helper-text + session-static fallback (`Fuel.Setup.*`) | Strategy Planner + PreRace adapter | per-tick/500 ms; session phase transitions; live/setup availability | preferred pre-green seams only | do not use for race-running refuel widgets |
-| `ProjectionLapTime_Stable`, `...Source` | stable-held + provenance/source-label | Pace & Projection | 500 ms poll; deadband hold; reset on runtime/session reset | preferred projection seam | do not touch |
-| `LiveProjectedDriveTimeAfterZero`, `LiveProjectedDriveSecondsRemaining`, `Fuel.After0.*` | live/raw + held-through-gap fallback between planner/live after-zero | Pace & Projection + Fuel Model | 500 ms poll; timer-zero/lap-cross transitions; reset | support/runtime projection seams; not primary dash headline | medium |
+| `LalaLaunch.PreRace.*`, `StrategyDash.*`, `Fuel.Setup.*` | planner-deterministic + helper-text + session-static fallback (`Fuel.Setup.*`) | Strategy Planner + PreRace adapter | per-tick/500 ms; session phase transitions; live/setup availability | preferred pre-green seams only | do not use for race-running refuel widgets |
+| `Fuel.ProjectionLapTime_Stable`, `Fuel.ProjectionLapTime_StableSource` | stable-held + provenance/source-label | Pace & Projection | 500 ms poll; deadband hold; reset on runtime/session reset | preferred projection seam | do not touch |
+| `Fuel.Live.DriveTimeAfterZero`, `Fuel.Live.ProjectedDriveSecondsRemaining`, `Fuel.After0.*` | live/raw + held-through-gap fallback between planner/live after-zero | Pace & Projection + Fuel Model | 500 ms poll; timer-zero/lap-cross transitions; reset | support/runtime projection seams; not primary dash headline | medium |
 | `Race.EndPhase*`, `Race.LastLapLikely` | debounced-state | RaceFinish lifecycle | per-tick with confidence/debounce; session/lifecycle reset | preferred finish-phase seam | do not touch |
 | `RaceFinish.*` | frozen-post-event + staged latch (class snapshot then player snapshot) | RaceFinish lifecycle | latch on finish triggers; reset when leaving finish lifecycle/session reset | preferred post-finish widgets | do not touch |
 
 ### Direct answers for Phase 3B questions
-1. Stable exports genuinely needed: `Fuel.LiveFuelPerLap_Stable`, `Fuel.LiveFuelPerLap_StableSource`, `Fuel.LiveFuelPerLap_StableConfidence`, `Fuel.LiveLapsRemainingInRace_Stable`, `ProjectionLapTime_Stable`, `ProjectionLapTime_StableSource`.
+1. Stable exports genuinely needed: `Fuel.LiveFuelPerLap_Stable`, `Fuel.LiveFuelPerLap_StableSource`, `Fuel.LiveFuelPerLap_StableConfidence`, `Fuel.LiveLapsRemainingInRace_Stable`, `Fuel.ProjectionLapTime_Stable`, `Fuel.ProjectionLapTime_StableSource`.
 2. `Fuel.LiveLapsRemainingInRace` is effectively already stable in current runtime flow, but should be treated as a compatibility mirror seam rather than the explicit contract anchor.
 3. `Fuel.LiveLapsRemainingInRace_Stable` adds explicit contract clarity/intent for dashboards/debug tools and isolates future rationalisation from the ambiguous non-suffixed name.
 4. `_Stable_S` adds EMA display smoothing only (visual anti-jitter), not new calculation authority.
@@ -315,7 +315,7 @@ This section documents current **as-implemented** temporal semantics without cha
    - frozen-post-event: `RaceFinish.*` snapshots.
    - held-through-gap: stable fuel/projection source/value holds, after-zero planner/live handoff holds.
    - debounced-state: pit-window state text transitions, `Race.EndPhase*` confidence staging.
-8. Preferred dashboard seams: runtime race work => `Fuel.Refuel.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Delta.*`, `Fuel.Contingency.*`, `Fuel.Pit.*`, `Pit.Box.*`, `ProjectionLapTime_Stable`, `Race.EndPhase*`, `RaceFinish.*`.
+8. Preferred dashboard seams: runtime race work => `Fuel.Refuel.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Delta.*`, `Fuel.Contingency.*`, `Fuel.Pit.*`, `Pit.Box.*`, `Fuel.ProjectionLapTime_Stable`, `Race.EndPhase*`, `RaceFinish.*`.
 9. Debug/provenance/internal-first seams: `...StableSource`, `...StableConfidence`, `Fuel.Refuel.BurnSource/LapSource/DataMode/BurnMode/SelectedBurnPerLap`, most explicit helper text fields.
 10. Future rationalisation candidates (not removal now): redundant mirror pairs around `LiveLapsRemainingInRace` vs `_Stable`, overlapping `_S` smoothing duplicates, helper/provenance naming consistency across fuel/projection families.
 


### PR DESCRIPTION
### Motivation
- Provide a single, canonical, analysis-first description of temporal semantics across fuel, pit, PreRace, StrategyDash, projection/pace and finish exports so future cleanup/removal work is safe. 
- Make explicit which exports are runtime tactical seams, planner seams, display-smoothed helpers, latched/frozen values, and provenance/debug tokens to avoid accidental merge of intents. 
- Record dashboard seam preferences, reset/invalidation triggers and a do-not-touch/high-risk list so consumers and future refactors remain safe.

### Description
- Added a new analysis section `Fuel Revamp Phase 3B — Temporal semantics and lifecycle classification` to `Docs/Subsystems/Fuel_Model.md` that includes the lifecycle matrix (temporal type, owner, reset triggers, dash preference, risk) and direct answers to the 10 Phase‑3B questions. 
- Documented dashboard seam recommendations (prefer `Fuel.Refuel.*` for runtime next-stop, prefer `_Stable` for numeric logic, `_S` exports are smoothing/display-only), future rationalisation candidates, and an explicit do-not-touch list. 
- Updated `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` to record this documentation-only analysis pass and to confirm no runtime exports, names, calculations or C# code were changed. 

### Testing
- Ran repository inspections and targeted searches (`rg`), file reads (`cat`), and export/code cross-checks against `LalaLaunch.cs`/`FuelCalcs.cs` to verify documentation claims; all checks completed without issue. 
- Verified diffs limited to documentation: `Docs/Subsystems/Fuel_Model.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`. 
- Confirmed no `.cs` runtime files were modified and no runtime calculations or export names changed (documentation-only update succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18111368ec832fb9da69fc4553a12b)