### PR TITLE
Docs: Fuel Revamp Phase 3C/3E design pass and Dashboard migration checklist (analysis-only)

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2698,3 +2698,19 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Guard still blocks SimHub fallback when no active/pending live context match exists (disconnected/unmatched planner selection), preventing stale cached DataCore fallback usage.
 - Preserved wet fuel basis when dry avg is missing: `LoadProfileData()` no longer blindly zeroes `_baseDryFuelPerLap` in that case; when wet avg exists it now seeds a non-zero synthetic dry basis from wet/factor to prevent later `ApplyWetFactor`/condition-refresh paths from collapsing wet fuel to zero.
 - DATA SAVED authority, Fuel.Refuel math, Pit.FuelControl, pit commands, manual entry semantics, and profile schema unchanged.
+
+## 2026-05-28 — Fuel Revamp Phase 3C Export Rationalisation design pass (analysis-only)
+- Classification: **internal-only** (analysis/docs only; no runtime or dashboard package edits).
+- Completed Phase 3C export-consumer mapping for temporal duplicate families across fuel/pit/strategy/projection seams.
+- Confirmed core guard remains enforced: no export removal/rename is allowed until both are mapped per export family:
+  - dashboard JSON/package consumer usage,
+  - internal C# consumer usage.
+- Current repo dashboard-package status for this branch: no dashboard JSON / Dash Studio package files are present in-repo to edit; dashboard contract mapping is therefore based on canonical dash integration/parameter docs and exported attach surface inventory.
+- Runtime boundaries preserved: no C# runtime math changes, no export attach changes, no compatibility cleanup/refactor, and no Property Snapshot grouping change required in this analysis pass.
+
+## 2026-05-28 — Fuel Revamp Phase 3E Dashboard Migration Design pass (no export removal)
+- Classification: **internal-only** (design/planning documentation only).
+- Reconfirmed strict migration rule: no export removal/rename until both mappings are complete and dashboard usage is migrated + validated.
+- Added Phase 3E dashboard migration design matrix and checklist to `Docs/Subsystems/Dash_Integration.md`.
+- Current workspace note: repository does not currently contain dashboard `.djson` files under `Docs/Dash Files/`; exact widget/formula replacement edits remain deferred to implementation phase with dashboard package files present.
+- Runtime boundaries preserved: no C# changes, no runtime formula changes, no export registration changes, no dashboard JSON edits.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1629,3 +1629,13 @@ Branch: work
 - 2026-05-19: PR #744 follow-up #2 landed: telemetry profile-fuel refresh now requires selected Strategy profile+track identity match and preserves non-manual source tracking when auto-applying Profile AVG/ECO/MAX.
 - 2026-05-19: PR #744 follow-up #3 landed: Profile AVG/ECO/MAX button handlers now use source-safe non-manual apply path, preserving telemetry-refresh eligibility for active Profile choice.
 - 2026-05-19: PR #744 follow-up #4 landed: wet derived-from-dry relevance now applies per active Profile choice (AVG/ECO/MAX) and profile fuel text sync no longer rounds numeric `FuelPerLap` through textbox parse-back.
+
+- 2026-05-28: Fuel Revamp Phase 3C Export Rationalisation design pass completed as analysis-only.
+  - mapped target fuel/pit/strategy/projection export families against internal C# defining/consumer seams and documented dashboard-consumer status;
+  - confirmed no export removal/rename, no runtime calculation change, no dashboard JSON/package change, and no compatibility cleanup performed;
+  - no Property Snapshot grouping update required in this phase (no export-surface change).
+
+- 2026-05-28: Fuel Revamp Phase 3E Dashboard Migration Design pass completed (design-only).
+  - documented mirror/smoothing consumer migration strategy and explicit no-change decisions for stable/source/confidence helpers;
+  - no export removed/renamed; no C# or dashboard `.djson` changes performed in this phase;
+  - implementation checklist/validation matrix prepared for future dashboard migration task once `.djson` package files are available in-repo for direct edits.

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -250,3 +250,36 @@ The v1 GitHub docs now present dashboards as the presentation layer across all s
 
 ## Fuel PROFILE provenance contract
 When `Fuel.LiveFuelPerLap_StableSource` resolves to `Profile`, runtime numeric fuel burn consumed by fuel outputs is profile-backed for that condition; SimHub/DataCore fallback must not be used in parallel as numeric authority.
+
+## Fuel Revamp Phase 3E — Dashboard migration design pass (no JSON edits)
+
+Date: 2026-05-28
+
+Design-only outcome:
+- No dashboard `.djson` files are currently present in this repository working tree under `Docs/Dash Files/` (or elsewhere), so exact widget/formula-line replacement edits cannot be executed in-repo in this phase.
+- Migration plan below is therefore a **pre-implementation checklist** anchored to canonical export semantics and the Phase 3D consumer findings referenced by task context.
+- No plugin exports are removed/renamed in this phase.
+
+### Phase 3E mirror/smoothing decision matrix
+| Current export consumer | Role intent | Smoothing display-critical? | Proposed action | Replacement status |
+|---|---|---:|---|---|
+| `Fuel.LiveLapsRemainingInRace_Stable_S` | anti-flicker numeric/text display | Yes | Keep current usage until implementation validation proves equivalent visual stability | Defer migration |
+| `Fuel.LiveLapsRemainingInRace_Stable` | stable numeric seam | Yes (stable) | Keep as canonical stable numeric seam where already used | No change |
+| `Fuel.LiveFuelPerLap_Stable` | stable burn display and pacing basis | Yes | Keep as canonical stable burn seam | No change |
+| `Fuel.LiveFuelPerLap_StableSource` | provenance/debug label | N/A | Keep helper usage for source text; do not replace with inferred dash logic | No change |
+| `Fuel.LiveFuelPerLap_StableConfidence` | confidence/state gating | Usually yes | Keep helper usage for confidence colours/visibility gates | No change |
+| `_S` mirrors (general) | display smoothing wrappers | Case-by-case | Migrate only where replay validation shows no flicker/regression | Conditional future |
+
+### Safe future replacement rules (implementation-phase only)
+- Prefer keeping `_Stable` over raw live exports for tactical fuel widgets.
+- Treat `_S` fields as display helpers, not math authority; remove only if equivalent anti-flicker behavior is proven in replay/live validation.
+- Preserve existing caution/warning thresholds, colour bands, and visibility timing during any property swap.
+- Do not migrate or reinterpret canonical tactical/lifecycle families (`Fuel.Refuel.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Delta.*`, `Fuel.Contingency.*`, `Fuel.Pit.*`, `Pit.Box.*`, `RaceFinish.*`, `Race.EndPhase*`, `Race.LastLapLikely`).
+
+### Per-dashboard migration checklist template (for later implementation)
+For each `.djson` dashboard file:
+1. Record widget id/name and formula path.
+2. Capture old export reference and intended visual role (text/colour/visibility/gauge/control).
+3. Propose new export only when visual equivalence is expected.
+4. Validate across: pre-grid, formation, race running, pit entry, in-box, pit exit, final stint, surplus, deficit, contingency transitions, and finish/post-finish if touched.
+5. Mark risk (`low/medium/high`) and keep compatibility export when risk is not low.


### PR DESCRIPTION
### Motivation
- Capture and document Phase 3C export rationalisation analysis and Phase 3E dashboard migration design outcomes for the Fuel Revamp effort without changing runtime code or exports.
- Preserve strict migration safety rules that prevent export removals/renames until both dashboard and internal C# consumers are mapped and validated.
- Provide a pre-implementation checklist and decision matrix so future dashboard `.djson` edits can be executed safely once dashboard package files are available in-repo.

### Description
- Added analysis/design notes to `Docs/Internal/Development_Changelog.md` describing Phase 3C export-consumer mapping and Phase 3E dashboard migration design, emphasizing no runtime changes and that no dashboard JSON files exist in-repo for edits.
- Updated `Docs/RepoStatus.md` with Phase 3C and Phase 3E design pass entries summarising export mapping, migration rules, and that no export removal/rename or C#/runtime changes were performed.
- Extended `Docs/Subsystems/Dash_Integration.md` with a Phase 3E migration section that includes a mirror/smoothing decision matrix, safe replacement rules, and a per-dashboard migration checklist for later implementation.
- All changes are documentation-only and explicitly state that runtime boundaries, exports, and C# behavior remain unchanged in this pass.

### Testing
- No automated unit or integration tests were modified or required because this is a documentation/analysis-only change.
- No code-path or runtime behavior was changed, so no runtime test execution was necessary.
- Standard repo CI that would run on code changes was not applicable to these docs-only edits (no test failures introduced by documentation updates).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182784a274832f815e46b1cfbd359e)