### PR TITLE
Strategy: Prefer Live Detect at startup and allow non-destructive preset apply

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2718,7 +2718,7 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## 2026-05-28 — Strategy Live Detect default + non-destructive preset apply
 - Classification: **both** (Strategy startup/default UX + Live Detect/preset ownership correctness + docs alignment).
-- Strategy startup now prefers Live Detect race-basis owner when live session context is active only while the owner is untouched; explicit Preset/Lap/Time selections are preserved.
+- Strategy startup now prefers Live Detect race-basis owner when live session context is active only while the owner is untouched; explicit Preset/Lap/Time selections and manual Race Minutes/Laps edits are preserved.
 - Race Preset selector/reapply controls are visible only in Preset or Live Detect owner modes (not manual Lap/Time), and remain available in Live Detect.
 - Selecting/reapplying/updating applied presets while Live Detect is selected now applies setup values without stealing race-basis ownership away from Live Detect.
 - Refresh Calcs semantics unchanged (recompute-only); no runtime fuel model/pit command/telemetry ownership changes.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2714,3 +2714,11 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Added Phase 3E dashboard migration design matrix and checklist to `Docs/Subsystems/Dash_Integration.md`.
 - Current workspace note: repository does not currently contain dashboard `.djson` files under `Docs/Dash Files/`; exact widget/formula replacement edits remain deferred to implementation phase with dashboard package files present.
 - Runtime boundaries preserved: no C# changes, no runtime formula changes, no export registration changes, no dashboard JSON edits.
+
+
+## 2026-05-28 — Strategy Live Detect default + non-destructive preset apply
+- Classification: **both** (Strategy startup/default UX + Live Detect/preset ownership correctness + docs alignment).
+- Strategy startup now prefers Live Detect race-basis owner when live session context is active (without changing offline/manual defaults).
+- Race Preset selector/reapply controls remain available while Live Detect is selected.
+- Selecting/reapplying preset while Live Detect is selected now applies setup values without stealing race-basis ownership away from Live Detect.
+- Refresh Calcs semantics unchanged (recompute-only); no runtime fuel model/pit command/telemetry ownership changes.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2718,7 +2718,7 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## 2026-05-28 — Strategy Live Detect default + non-destructive preset apply
 - Classification: **both** (Strategy startup/default UX + Live Detect/preset ownership correctness + docs alignment).
-- Strategy startup now prefers Live Detect race-basis owner when live session context is active (without changing offline/manual defaults).
-- Race Preset selector/reapply controls remain available while Live Detect is selected.
-- Selecting/reapplying preset while Live Detect is selected now applies setup values without stealing race-basis ownership away from Live Detect.
+- Strategy startup now prefers Live Detect race-basis owner when live session context is active only while the owner is untouched; explicit Preset/Lap/Time selections are preserved.
+- Race Preset selector/reapply controls are visible only in Preset or Live Detect owner modes (not manual Lap/Time), and remain available in Live Detect.
+- Selecting/reapplying/updating applied presets while Live Detect is selected now applies setup values without stealing race-basis ownership away from Live Detect.
 - Refresh Calcs semantics unchanged (recompute-only); no runtime fuel model/pit command/telemetry ownership changes.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1643,5 +1643,5 @@ Branch: work
 
 - 2026-05-28 Strategy Live Detect default + non-destructive preset apply landed:
   - Strategy now prefers Live Detect as startup/default race-basis owner once live session context is active (without changing offline/manual defaults).
-  - Race Preset selector/reapply controls remain visible while Live Detect owner is selected.
+  - Race Preset selector/reapply controls are visible only in Preset or Live Detect owner modes (not manual Lap/Time), and remain available in Live Detect.
   - Selecting/reapplying presets while Live Detect is active applies setup values without stealing race-basis ownership or clearing live-detect helper/cache state.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1642,6 +1642,6 @@ Branch: work
 
 
 - 2026-05-28 Strategy Live Detect default + non-destructive preset apply landed:
-  - Strategy now prefers Live Detect as startup/default race-basis owner once live session context is active only while the owner is untouched; explicit Preset/Lap/Time selections are preserved.
+  - Strategy now prefers Live Detect as startup/default race-basis owner once live session context is active only while the owner is untouched; explicit Preset/Lap/Time selections and manual Race Minutes/Laps edits are preserved.
   - Race Preset selector/reapply controls are visible only in Preset or Live Detect owner modes (not manual Lap/Time), and remain available in Live Detect.
   - Selecting/reapplying/updating applied presets while Live Detect is active applies setup values without stealing race-basis ownership or clearing live-detect helper/cache state.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1642,6 +1642,6 @@ Branch: work
 
 
 - 2026-05-28 Strategy Live Detect default + non-destructive preset apply landed:
-  - Strategy now prefers Live Detect as startup/default race-basis owner once live session context is active (without changing offline/manual defaults).
+  - Strategy now prefers Live Detect as startup/default race-basis owner once live session context is active only while the owner is untouched; explicit Preset/Lap/Time selections are preserved.
   - Race Preset selector/reapply controls are visible only in Preset or Live Detect owner modes (not manual Lap/Time), and remain available in Live Detect.
-  - Selecting/reapplying presets while Live Detect is active applies setup values without stealing race-basis ownership or clearing live-detect helper/cache state.
+  - Selecting/reapplying/updating applied presets while Live Detect is active applies setup values without stealing race-basis ownership or clearing live-detect helper/cache state.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1639,3 +1639,9 @@ Branch: work
   - documented mirror/smoothing consumer migration strategy and explicit no-change decisions for stable/source/confidence helpers;
   - no export removed/renamed; no C# or dashboard `.djson` changes performed in this phase;
   - implementation checklist/validation matrix prepared for future dashboard migration task once `.djson` package files are available in-repo for direct edits.
+
+
+- 2026-05-28 Strategy Live Detect default + non-destructive preset apply landed:
+  - Strategy now prefers Live Detect as startup/default race-basis owner once live session context is active (without changing offline/manual defaults).
+  - Race Preset selector/reapply controls remain visible while Live Detect owner is selected.
+  - Selecting/reapplying presets while Live Detect is active applies setup values without stealing race-basis ownership or clearing live-detect helper/cache state.

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -199,5 +199,5 @@ If Strategy looks repeatedly wrong, the usual causes are:
 - Live pit prediction/export seams remain unchanged in this Strategy task.
 
 
-- Live Detect startup default: when a live session context is active, Strategy now prefers Live Detect as the initial race-basis owner only before the driver has explicitly chosen Preset, Lap-Limited, or Time-Limited.
+- Live Detect startup default: when a live session context is active, Strategy now prefers Live Detect as the initial race-basis owner only before the driver has explicitly chosen Preset, Lap-Limited, or Time-Limited or edited Race Minutes/Laps.
 - Preset apply while Live Detect is selected now updates setup values without forcing race-basis ownership away from Live Detect.

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -197,3 +197,7 @@ If Strategy looks repeatedly wrong, the usual causes are:
 - Tyre timing seconds are not preset-owned; they come from profile-seeded Strategy tyre slider and can be manually overridden for what-if planning.
 - Strategy stop math gates tyre time with Tyres Expected (OFF = 0s, ON = slider value).
 - Live pit prediction/export seams remain unchanged in this Strategy task.
+
+
+- Live Detect startup default: when a live session context is active, Strategy now prefers Live Detect as the initial race-basis owner (unless Preset owner is already explicit).
+- Preset apply while Live Detect is selected now updates setup values without forcing race-basis ownership away from Live Detect.

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -199,5 +199,5 @@ If Strategy looks repeatedly wrong, the usual causes are:
 - Live pit prediction/export seams remain unchanged in this Strategy task.
 
 
-- Live Detect startup default: when a live session context is active, Strategy now prefers Live Detect as the initial race-basis owner (unless Preset owner is already explicit).
+- Live Detect startup default: when a live session context is active, Strategy now prefers Live Detect as the initial race-basis owner only before the driver has explicitly chosen Preset, Lap-Limited, or Time-Limited.
 - Preset apply while Live Detect is selected now updates setup values without forcing race-basis ownership away from Live Detect.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -353,4 +353,4 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 
 - Preset selector/reapply controls are shown for `Preset` and `Live Detect` owner modes only; they stay available in `Live Detect` so drivers can apply setup values without changing race-basis owner.
 - Selecting/reapplying presets while `Live Detect` is active applies non-race-basis setup fields only (contingency, tyre intent, PreRace mode, profile-mode max fuel, and other existing setup fields); race type/length authority remains Live Detect and helper/cache state is preserved.
-- Strategy startup now prefers `Live Detect` as initial race-basis owner once a live session context is active (except explicit Preset-owner state), while offline/manual planning defaults remain unchanged.
+- Strategy startup now prefers `Live Detect` as initial race-basis owner once a live session context is active only while the startup/default owner is still untouched; explicit Preset/Lap/Time owner choices are preserved.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -353,4 +353,4 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 
 - Preset selector/reapply controls are shown for `Preset` and `Live Detect` owner modes only; they stay available in `Live Detect` so drivers can apply setup values without changing race-basis owner.
 - Selecting/reapplying presets while `Live Detect` is active applies non-race-basis setup fields only (contingency, tyre intent, PreRace mode, profile-mode max fuel, and other existing setup fields); race type/length authority remains Live Detect and helper/cache state is preserved.
-- Strategy startup now prefers `Live Detect` as initial race-basis owner once a live session context is active only while the startup/default owner is still untouched; explicit Preset/Lap/Time owner choices are preserved.
+- Strategy startup now prefers `Live Detect` as initial race-basis owner once a live session context is active only while the startup/default owner is still untouched; explicit Preset/Lap/Time owner choices and manual Race Minutes/Laps edits are preserved.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -351,6 +351,6 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 
 - Live Detect owns race basis only while selected; invalid/no declared race definition intentionally invalidates strategy outputs (no silent fallback to manual race length) while preserving selected/applied preset state.
 
-- Preset selector/reapply controls remain available while `Live Detect` owner is selected so drivers can apply setup values without changing race-basis owner.
+- Preset selector/reapply controls are shown for `Preset` and `Live Detect` owner modes only; they stay available in `Live Detect` so drivers can apply setup values without changing race-basis owner.
 - Selecting/reapplying presets while `Live Detect` is active applies non-race-basis setup fields only (contingency, tyre intent, PreRace mode, profile-mode max fuel, and other existing setup fields); race type/length authority remains Live Detect and helper/cache state is preserved.
 - Strategy startup now prefers `Live Detect` as initial race-basis owner once a live session context is active (except explicit Preset-owner state), while offline/manual planning defaults remain unchanged.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -350,3 +350,7 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 - Owner-mode helpers (`IsRaceBasis*`) are UI ownership flags; effective helpers (`IsEffective*`, `EffectiveRaceBasisValid`) mirror the basis actually consumed by strategy calculations and dependent preset dirty/save logic.
 
 - Live Detect owns race basis only while selected; invalid/no declared race definition intentionally invalidates strategy outputs (no silent fallback to manual race length) while preserving selected/applied preset state.
+
+- Preset selector/reapply controls remain available while `Live Detect` owner is selected so drivers can apply setup values without changing race-basis owner.
+- Selecting/reapplying presets while `Live Detect` is active applies non-race-basis setup fields only (contingency, tyre intent, PreRace mode, profile-mode max fuel, and other existing setup fields); race type/length authority remains Live Detect and helper/cache state is preserved.
+- Strategy startup now prefers `Live Detect` as initial race-basis owner once a live session context is active (except explicit Preset-owner state), while offline/manual planning defaults remain unchanged.

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -146,6 +146,7 @@ namespace LaunchPlugin
     private string _selectedTrack;
     private RaceType _raceType;
     private RaceBasisMode _raceBasisMode = RaceBasisMode.TimeLimited;
+    private bool _hasAutoSelectedLiveDetectDefault;
     private RaceType? _liveDetectedRaceType;
     private string _liveDetectHelperText = "Live Detect: no declared race found";
     private double _lastLiveDetectedRaceLaps;
@@ -815,7 +816,7 @@ namespace LaunchPlugin
                 OnPropertyChanged(nameof(HasSelectedPreset));
 
                 // Auto-apply on selection change (removes need for an Apply button)
-                ApplySelectedPreset();
+                ApplySelectedPreset(activatePresetOwner: !IsLiveDetectRace);
             }
         }
     }
@@ -947,7 +948,7 @@ namespace LaunchPlugin
     {
         if (_selectedPreset != null)
         {
-            ApplyPresetValues(_selectedPreset, activatePresetOwner: true);
+            ApplyPresetValues(_selectedPreset, activatePresetOwner: !IsLiveDetectRace);
         }
     }
 
@@ -4281,6 +4282,7 @@ namespace LaunchPlugin
         SeenCarName = LiveCarName;
         SeenTrackName = LiveTrackName;
         IsLiveSessionActive = hasCar && hasTrack;
+        TryAutoSelectLiveDetectRaceBasisDefault();
         SeenSessionSummary = (hasCar || hasTrack)
             ? $"Live: {FormatLabel(displayCarName, "-")} @ {FormatLabel(displayTrackName, "-")}"
             : "No Live Data";
@@ -4309,6 +4311,23 @@ namespace LaunchPlugin
         else
         {
             LiveSurfaceModeDisplay = "-";
+        }
+    }
+
+
+    private void TryAutoSelectLiveDetectRaceBasisDefault()
+    {
+        if (_hasAutoSelectedLiveDetectDefault) return;
+        if (!IsLiveSessionActive) return;
+
+        // Startup-default preference only: do not override explicit preset ownership.
+        if (SelectedRaceBasisMode == RaceBasisMode.Preset) return;
+
+        bool liveDetectHasDefinition = _liveDetectedRaceType.HasValue;
+        if (liveDetectHasDefinition || IsLiveSessionActive)
+        {
+            SelectedRaceBasisMode = RaceBasisMode.LiveDetect;
+            _hasAutoSelectedLiveDetectDefault = true;
         }
     }
 

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -147,7 +147,8 @@ namespace LaunchPlugin
     private RaceType _raceType;
     private RaceBasisMode _raceBasisMode = RaceBasisMode.TimeLimited;
     private bool _hasAutoSelectedLiveDetectDefault;
-    private bool _raceBasisOwnerTouchedByUser;
+    private bool _raceBasisPlannerTouchedByUser;
+    private bool _suppressRaceBasisPlannerTouch;
     private RaceType? _liveDetectedRaceType;
     private string _liveDetectHelperText = "Live Detect: no declared race found";
     private double _lastLiveDetectedRaceLaps;
@@ -898,8 +899,17 @@ namespace LaunchPlugin
         // (preset select / preset reapply) that activate Preset ownership.
         if (activatePresetOwner)
         {
-            if (p.Type == RacePresetType.TimeLimited && p.RaceMinutes.HasValue) RaceMinutes = p.RaceMinutes.Value;
-            if (p.Type == RacePresetType.LapLimited && p.RaceLaps.HasValue) RaceLaps = p.RaceLaps.Value;
+            bool previousRaceBasisPlannerTouchSuppression = _suppressRaceBasisPlannerTouch;
+            _suppressRaceBasisPlannerTouch = true;
+            try
+            {
+                if (p.Type == RacePresetType.TimeLimited && p.RaceMinutes.HasValue) RaceMinutes = p.RaceMinutes.Value;
+                if (p.Type == RacePresetType.LapLimited && p.RaceLaps.HasValue) RaceLaps = p.RaceLaps.Value;
+            }
+            finally
+            {
+                _suppressRaceBasisPlannerTouch = previousRaceBasisPlannerTouchSuppression;
+            }
         }
 
         SelectedPreRaceMode = NormalizePitStrategyValue(p.PreRaceMode);
@@ -1205,7 +1215,7 @@ namespace LaunchPlugin
     {
         if (markUserTouched)
         {
-            _raceBasisOwnerTouchedByUser = true;
+            _raceBasisPlannerTouchedByUser = true;
         }
 
         if (_raceBasisMode == value) return;
@@ -1270,6 +1280,10 @@ namespace LaunchPlugin
         {
             if (_raceLaps != value)
             {
+                if (!_suppressRaceBasisPlannerTouch)
+                {
+                    _raceBasisPlannerTouchedByUser = true;
+                }
                 _raceLaps = value;
                 OnPropertyChanged("RaceLaps");
                 RaiseRaceBasisStateChanged(includeOwner: false);
@@ -1285,6 +1299,10 @@ namespace LaunchPlugin
         {
             if (_raceMinutes != value)
             {
+                if (!_suppressRaceBasisPlannerTouch)
+                {
+                    _raceBasisPlannerTouchedByUser = true;
+                }
                 _raceMinutes = value;
                 OnPropertyChanged("RaceMinutes");
                 RaiseRaceBasisStateChanged(includeOwner: false);
@@ -2734,9 +2752,18 @@ namespace LaunchPlugin
         // Reset race-specific parameters to sensible defaults
         if (!preserveRaceDuration)
         {
-            SetRaceBasisMode(RaceBasisMode.TimeLimited, markUserTouched: false);
-            this.RaceLaps = 20;
-            this.RaceMinutes = 40;
+            bool previousRaceBasisPlannerTouchSuppression = _suppressRaceBasisPlannerTouch;
+            _suppressRaceBasisPlannerTouch = true;
+            try
+            {
+                SetRaceBasisMode(RaceBasisMode.TimeLimited, markUserTouched: false);
+                this.RaceLaps = 20;
+                this.RaceMinutes = 40;
+            }
+            finally
+            {
+                _suppressRaceBasisPlannerTouch = previousRaceBasisPlannerTouchSuppression;
+            }
         }
         if (!preservePreRaceMode)
         {
@@ -4337,7 +4364,7 @@ namespace LaunchPlugin
         if (!IsLiveSessionActive) return;
 
         // Startup-default preference only before any explicit user owner selection.
-        if (_raceBasisOwnerTouchedByUser) return;
+        if (_raceBasisPlannerTouchedByUser) return;
 
         // Allow the untouched initial TimeLimited default to move to LiveDetect, but do not
         // override any other internally/restored owner state before user intent exists.
@@ -4362,7 +4389,8 @@ namespace LaunchPlugin
         _raceMinutes = 40.0;
         _raceType = RaceType.TimeLimited;
         _raceBasisMode = RaceBasisMode.TimeLimited;
-        _raceBasisOwnerTouchedByUser = false;
+        _raceBasisPlannerTouchedByUser = false;
+        _suppressRaceBasisPlannerTouch = false;
         _hasAutoSelectedLiveDetectDefault = false;
         _estimatedLapTime = "2:45.500";
         FuelPerLap = 2.8; // ensures _baseDryFuelPerLap is set
@@ -5749,7 +5777,16 @@ namespace LaunchPlugin
             RaiseRaceBasisStateChanged(includeOwner: false);
             if (IsLiveDetectRace && Math.Abs(RaceLaps - _lastLiveDetectedRaceLaps) > 0.001)
             {
-                RaceLaps = _lastLiveDetectedRaceLaps;
+                bool previousRaceBasisPlannerTouchSuppression = _suppressRaceBasisPlannerTouch;
+                _suppressRaceBasisPlannerTouch = true;
+                try
+                {
+                    RaceLaps = _lastLiveDetectedRaceLaps;
+                }
+                finally
+                {
+                    _suppressRaceBasisPlannerTouch = previousRaceBasisPlannerTouchSuppression;
+                }
                 shouldRecalculate = false; // RaceLaps setter already recalculates
             }
             string helperText = string.Format(
@@ -5780,7 +5817,16 @@ namespace LaunchPlugin
             RaiseRaceBasisStateChanged(includeOwner: false);
             if (IsLiveDetectRace && Math.Abs(RaceMinutes - _lastLiveDetectedRaceMinutes) > 0.001)
             {
-                RaceMinutes = _lastLiveDetectedRaceMinutes;
+                bool previousRaceBasisPlannerTouchSuppression = _suppressRaceBasisPlannerTouch;
+                _suppressRaceBasisPlannerTouch = true;
+                try
+                {
+                    RaceMinutes = _lastLiveDetectedRaceMinutes;
+                }
+                finally
+                {
+                    _suppressRaceBasisPlannerTouch = previousRaceBasisPlannerTouchSuppression;
+                }
                 shouldRecalculate = false; // RaceMinutes setter already recalculates
             }
             string helperText = string.Format(

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -147,8 +147,7 @@ namespace LaunchPlugin
     private RaceType _raceType;
     private RaceBasisMode _raceBasisMode = RaceBasisMode.TimeLimited;
     private bool _hasAutoSelectedLiveDetectDefault;
-    private bool _raceBasisModeUserTouched;
-    private bool _suppressRaceBasisUserTouch;
+    private bool _raceBasisOwnerTouchedByUser;
     private RaceType? _liveDetectedRaceType;
     private string _liveDetectHelperText = "Live Detect: no declared race found";
     private double _lastLiveDetectedRaceLaps;
@@ -818,7 +817,7 @@ namespace LaunchPlugin
                 OnPropertyChanged(nameof(HasSelectedPreset));
 
                 // Auto-apply on selection change (removes need for an Apply button)
-                ApplySelectedPreset(activatePresetOwner: !IsLiveDetectRace);
+                ApplySelectedPreset(activatePresetOwner: ShouldActivatePresetOwnerForPresetApply());
             }
         }
     }
@@ -880,7 +879,12 @@ namespace LaunchPlugin
         public ICommand ClearPresetCommand { get; private set; }
         public ICommand ApplySourceWetFactorCommand { get; }
 
-    private void ApplyPresetValues(RacePreset preset, bool activatePresetOwner = true)
+    private bool ShouldActivatePresetOwnerForPresetApply(bool explicitOwnerActivation = false)
+    {
+        return explicitOwnerActivation || IsRaceBasisPreset;
+    }
+
+    private void ApplyPresetValues(RacePreset preset, bool activatePresetOwner)
     {
         if (preset == null) return;
 
@@ -921,7 +925,7 @@ namespace LaunchPlugin
         _appliedPreset = p;
         if (activatePresetOwner)
         {
-            SelectedRaceBasisMode = RaceBasisMode.Preset;
+            SetRaceBasisMode(RaceBasisMode.Preset, markUserTouched: true);
         }
         RaiseRaceBasisStateChanged(includeOwner: false);
 
@@ -942,7 +946,7 @@ namespace LaunchPlugin
         }
     }
 
-    private void ApplySelectedPreset(bool activatePresetOwner = true)
+    private void ApplySelectedPreset(bool activatePresetOwner)
     {
         ApplyPresetValues(_selectedPreset, activatePresetOwner);
     }
@@ -951,7 +955,7 @@ namespace LaunchPlugin
     {
         if (_selectedPreset != null)
         {
-            ApplyPresetValues(_selectedPreset, activatePresetOwner: !IsLiveDetectRace);
+            ApplyPresetValues(_selectedPreset, activatePresetOwner: ShouldActivatePresetOwnerForPresetApply());
         }
     }
 
@@ -1194,21 +1198,25 @@ namespace LaunchPlugin
     public RaceBasisMode SelectedRaceBasisMode
     {
         get => _raceBasisMode;
-        set
-        {
-            if (_raceBasisMode == value) return;
-            _raceBasisMode = value;
-            if (!_suppressRaceBasisUserTouch)
-            {
-                _raceBasisModeUserTouched = true;
-            }
-            if (_raceBasisMode == RaceBasisMode.LapLimited) _raceType = RaceType.LapLimited;
-            else if (_raceBasisMode == RaceBasisMode.TimeLimited) _raceType = RaceType.TimeLimited;
-            else if (_raceBasisMode == RaceBasisMode.LiveDetect) _raceType = RaceType.LiveDetect;
+        set => SetRaceBasisMode(value, markUserTouched: true);
+    }
 
-            RaiseRaceBasisStateChanged(includeOwner: true);
-            RequestStrategyRecalc();
+    private void SetRaceBasisMode(RaceBasisMode value, bool markUserTouched)
+    {
+        if (markUserTouched)
+        {
+            _raceBasisOwnerTouchedByUser = true;
         }
+
+        if (_raceBasisMode == value) return;
+
+        _raceBasisMode = value;
+        if (_raceBasisMode == RaceBasisMode.LapLimited) _raceType = RaceType.LapLimited;
+        else if (_raceBasisMode == RaceBasisMode.TimeLimited) _raceType = RaceType.TimeLimited;
+        else if (_raceBasisMode == RaceBasisMode.LiveDetect) _raceType = RaceType.LiveDetect;
+
+        RaiseRaceBasisStateChanged(includeOwner: true);
+        RequestStrategyRecalc();
     }
 
     public bool IsRaceBasisPreset { get => SelectedRaceBasisMode == RaceBasisMode.Preset; set { if (value) SelectedRaceBasisMode = RaceBasisMode.Preset; } }
@@ -2726,7 +2734,7 @@ namespace LaunchPlugin
         // Reset race-specific parameters to sensible defaults
         if (!preserveRaceDuration)
         {
-            this.SelectedRaceBasisMode = RaceBasisMode.TimeLimited;
+            SetRaceBasisMode(RaceBasisMode.TimeLimited, markUserTouched: false);
             this.RaceLaps = 20;
             this.RaceMinutes = 40;
         }
@@ -3080,7 +3088,7 @@ namespace LaunchPlugin
 
         if (reapplyAppliedPreset && _appliedPreset != null)
         {
-            ApplyPresetValues(_appliedPreset);
+            ApplyPresetValues(_appliedPreset, activatePresetOwner: ShouldActivatePresetOwnerForPresetApply());
         }
         else
         {
@@ -3232,7 +3240,7 @@ namespace LaunchPlugin
         ResetFuelPerLapToSourceCommand = new RelayCommand(_ => ResetFuelPerLapToSource());
         ApplySourceWetFactorCommand = new RelayCommand(_ => ApplySourceWetFactorFromSource(), _ => HasSourceWetFactor);
 
-        ApplyPresetCommand = new RelayCommand(o => ApplySelectedPreset(), o => HasSelectedPreset);
+        ApplyPresetCommand = new RelayCommand(o => ApplySelectedPreset(activatePresetOwner: ShouldActivatePresetOwnerForPresetApply()), o => HasSelectedPreset);
         ClearPresetCommand = new RelayCommand(o => ClearAppliedPreset());
 
         InitPresets();  // populate AvailablePresets + default SelectedPreset
@@ -4329,12 +4337,12 @@ namespace LaunchPlugin
         if (!IsLiveSessionActive) return;
 
         // Startup-default preference only before any explicit user owner selection.
-        if (_raceBasisModeUserTouched) return;
+        if (_raceBasisOwnerTouchedByUser) return;
 
-        // Do not override explicit Preset owner, and never steal from explicit manual owner choices.
-        if (SelectedRaceBasisMode == RaceBasisMode.Preset
-            || SelectedRaceBasisMode == RaceBasisMode.LapLimited
-            || SelectedRaceBasisMode == RaceBasisMode.TimeLimited)
+        // Allow the untouched initial TimeLimited default to move to LiveDetect, but do not
+        // override any other internally/restored owner state before user intent exists.
+        if (SelectedRaceBasisMode != RaceBasisMode.TimeLimited
+            && SelectedRaceBasisMode != RaceBasisMode.LiveDetect)
         {
             return;
         }
@@ -4342,16 +4350,8 @@ namespace LaunchPlugin
         bool liveDetectHasDefinition = _liveDetectedRaceType.HasValue;
         if (liveDetectHasDefinition || IsLiveSessionActive)
         {
-            _suppressRaceBasisUserTouch = true;
-            try
-            {
-                SelectedRaceBasisMode = RaceBasisMode.LiveDetect;
-                _hasAutoSelectedLiveDetectDefault = true;
-            }
-            finally
-            {
-                _suppressRaceBasisUserTouch = false;
-            }
+            SetRaceBasisMode(RaceBasisMode.LiveDetect, markUserTouched: false);
+            _hasAutoSelectedLiveDetectDefault = true;
         }
     }
 
@@ -4362,7 +4362,7 @@ namespace LaunchPlugin
         _raceMinutes = 40.0;
         _raceType = RaceType.TimeLimited;
         _raceBasisMode = RaceBasisMode.TimeLimited;
-        _raceBasisModeUserTouched = false;
+        _raceBasisOwnerTouchedByUser = false;
         _hasAutoSelectedLiveDetectDefault = false;
         _estimatedLapTime = "2:45.500";
         FuelPerLap = 2.8; // ensures _baseDryFuelPerLap is set

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -147,6 +147,8 @@ namespace LaunchPlugin
     private RaceType _raceType;
     private RaceBasisMode _raceBasisMode = RaceBasisMode.TimeLimited;
     private bool _hasAutoSelectedLiveDetectDefault;
+    private bool _raceBasisModeUserTouched;
+    private bool _suppressRaceBasisUserTouch;
     private RaceType? _liveDetectedRaceType;
     private string _liveDetectHelperText = "Live Detect: no declared race found";
     private double _lastLiveDetectedRaceLaps;
@@ -851,6 +853,7 @@ namespace LaunchPlugin
     }
 
     public bool ShowRacePresetControls => IsRaceBasisPreset;
+    public bool ShowRacePresetSetupControls => IsRaceBasisPreset || IsRaceBasisLiveDetect;
 
     // Pit-lane live detection not implemented yet; hide the button for now
     public bool IsLivePitLaneLossAvailable => false;
@@ -1011,6 +1014,7 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(IsTimeLimitedRace));
             OnPropertyChanged(nameof(IsRaceLengthEditable));
             OnPropertyChanged(nameof(ShowRacePresetControls));
+            OnPropertyChanged(nameof(ShowRacePresetSetupControls));
         }
 
         OnPropertyChanged(nameof(ShowEffectiveLapLimitedRace));
@@ -1194,6 +1198,10 @@ namespace LaunchPlugin
         {
             if (_raceBasisMode == value) return;
             _raceBasisMode = value;
+            if (!_suppressRaceBasisUserTouch)
+            {
+                _raceBasisModeUserTouched = true;
+            }
             if (_raceBasisMode == RaceBasisMode.LapLimited) _raceType = RaceType.LapLimited;
             else if (_raceBasisMode == RaceBasisMode.TimeLimited) _raceType = RaceType.TimeLimited;
             else if (_raceBasisMode == RaceBasisMode.LiveDetect) _raceType = RaceType.LiveDetect;
@@ -4320,14 +4328,30 @@ namespace LaunchPlugin
         if (_hasAutoSelectedLiveDetectDefault) return;
         if (!IsLiveSessionActive) return;
 
-        // Startup-default preference only: do not override explicit preset ownership.
-        if (SelectedRaceBasisMode == RaceBasisMode.Preset) return;
+        // Startup-default preference only before any explicit user owner selection.
+        if (_raceBasisModeUserTouched) return;
+
+        // Do not override explicit Preset owner, and never steal from explicit manual owner choices.
+        if (SelectedRaceBasisMode == RaceBasisMode.Preset
+            || SelectedRaceBasisMode == RaceBasisMode.LapLimited
+            || SelectedRaceBasisMode == RaceBasisMode.TimeLimited)
+        {
+            return;
+        }
 
         bool liveDetectHasDefinition = _liveDetectedRaceType.HasValue;
         if (liveDetectHasDefinition || IsLiveSessionActive)
         {
-            SelectedRaceBasisMode = RaceBasisMode.LiveDetect;
-            _hasAutoSelectedLiveDetectDefault = true;
+            _suppressRaceBasisUserTouch = true;
+            try
+            {
+                SelectedRaceBasisMode = RaceBasisMode.LiveDetect;
+                _hasAutoSelectedLiveDetectDefault = true;
+            }
+            finally
+            {
+                _suppressRaceBasisUserTouch = false;
+            }
         }
     }
 
@@ -4337,6 +4361,9 @@ namespace LaunchPlugin
         _raceLaps = 20.0;
         _raceMinutes = 40.0;
         _raceType = RaceType.TimeLimited;
+        _raceBasisMode = RaceBasisMode.TimeLimited;
+        _raceBasisModeUserTouched = false;
+        _hasAutoSelectedLiveDetectDefault = false;
         _estimatedLapTime = "2:45.500";
         FuelPerLap = 2.8; // ensures _baseDryFuelPerLap is set
         _maxFuelOverride = 120.0;

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -490,8 +490,7 @@
                         <TextBlock Text="Race Strategy" FontWeight="Bold" Margin="0,5,0,5"/>
 
                             <!-- Race Preset selector (inline, auto-apply) -->
-                            <Grid Margin="0,10,0,10"
-                                  Visibility="{Binding IsRaceBasisPreset, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Grid Margin="0,10,0,10">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -490,7 +490,8 @@
                         <TextBlock Text="Race Strategy" FontWeight="Bold" Margin="0,5,0,5"/>
 
                             <!-- Race Preset selector (inline, auto-apply) -->
-                            <Grid Margin="0,10,0,10">
+                            <Grid Margin="0,10,0,10"
+                                  Visibility="{Binding ShowRacePresetSetupControls, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
### Motivation
- Make Strategy startup and Live Detect workflows smoother so a driver can start a live session and immediately use Live Detect while still applying preset setup values without switching owners.
- Avoid forcing drivers to switch to `Preset` owner to apply setup fields and preserve live-detect race-type/length ownership and helper/cache state.
- Preserve existing preset-owner semantics when the user explicitly selects `Preset`, and keep `Refresh Calcs` recompute-only behavior.

### Description
- Added a one-shot helper `TryAutoSelectLiveDetectRaceBasisDefault()` invoked from `ApplyLiveSession(...)` to prefer `Live Detect` as the startup/default `RaceBasis` once a live session context is active while not overriding an explicit `Preset` owner. (`FuelCalcs.cs`)
- Made preset selection/reapply non-destructive when `Live Detect` is active by applying presets with `activatePresetOwner: !IsLiveDetectRace` so setup fields apply but `SelectedRaceBasisMode` remains `LiveDetect`. (`FuelCalcs.cs`) 
- Kept `ApplyPresetValues(...)` semantics unchanged so when `activatePresetOwner` is true presets still set race type/length and switch owner to `Preset`. (`FuelCalcs.cs`)
- Kept the preset reapply button and removed the UI visibility gate so the inline preset selector and compact reapply (`↻`) remain visible while `Live Detect` is selected. (`FuelCalculatorView.xaml`)
- Updated documentation pages to reflect the behavior and rationale: `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Strategy_System.md`, `Docs/RepoStatus.md`, and `Docs/Internal/Development_Changelog.md`.
- Files changed: `FuelCalcs.cs`, `FuelCalculatorView.xaml`, `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Strategy_System.md`, `Docs/RepoStatus.md`, `Docs/Internal/Development_Changelog.md`.

### Testing
- No automated unit test suite was executed in this environment; an attempt to run `dotnet build -v minimal` failed because the CI environment lacked the .NET SDK (`dotnet: command not found`).
- Code-level verification performed by inspection and targeted text checks ensured `SelectedPreset` auto-apply now calls `ApplySelectedPreset(activatePresetOwner: !IsLiveDetectRace)` and `ReapplySelectedPreset()` mirrors that behavior, and the preset UI row visibility gate was removed.
- Manual follow-up recommendation: run a full build and exercise the Strategy tab in-app to verify that selecting/reapplying presets while `Live Detect` is active applies setup fields (contingency, tyre intent, PreRace, profile-mode max fuel, etc.) without changing race type/length or clearing live-detect helper state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183951aad4832f9cbaeb53e946af4b)