### PR TITLE
Pass CarSA checkpoint-gap delegate to Opponents update to avoid same-tick overwrite

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,5 +1,12 @@
 # Development Changelog
 
+## 2026-05-31 — Opponents CarSA checkpoint seam same-tick overwrite fix
+
+- Fixed the ordinary `UpdateLiveProperties(...)` Opponents refresh so it passes the existing CarSA `TryGetCheckpointGapSec` delegate when CarSA is available instead of overwriting a same-tick preferred `Opp.Ahead1` / `Opp.Behind1` checkpoint gap with native progress fallback.
+- Preserved the existing duplicate refresh timing, Opponents RaceProgress-first target selection, native fallback rules, pit-exit behavior, League Class matching, H2H selector ownership, and all export names.
+- Changelog impact: internal runtime correctness fix; no public release-note update in this task.
+- Property Snapshot list reviewed: yes, no group change required because existing `Opp.*` exports remain in the same `CarOppH2H` group and no property names changed.
+
 ## 2026-05-31 — PR #767 PreRace planner-authority review follow-up
 - Classification: **both** (dashboard-facing PreRace authority correctness plus internal seam documentation).
 - Manual Dry/Wet planner authority now rejects unknown live condition as well as known conflicts; automatic condition mode remains allowed.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -5,6 +5,11 @@ Last updated: 2026-05-31
 Branch: work
 
 ## Current status
+- 2026-05-31: Opponents CarSA checkpoint seam same-tick overwrite wiring fix validated.
+  - The ordinary `UpdateLiveProperties(...)` Opponents refresh now passes the CarSA `TryGetCheckpointGapSec` delegate when CarSA is available, so valid `Opp.Ahead1` / `Opp.Behind1` preferred checkpoint gaps are no longer replaced by same-tick native progress fallback before export.
+  - Preserved duplicate refresh timing, native fallback behavior, Opponents ordering, pit-exit behavior, League Class matching, H2H selector ownership, and all export names.
+  - Property Snapshot list reviewed: yes, no group change required because existing `Opp.*` exports remain in the same `CarOppH2H` group and no property names changed.
+
 - 2026-05-31: PR #767 PreRace planner-authority review follow-up landed.
   - Manual Dry/Wet planner authority now requires a known matching live condition; unknown live condition falls back safely.
   - Timed authority now applies a strict `0.01`-minute PreRace-specific tolerance alongside the existing strict `0.001`-lap tolerance without changing the shared coarse planner/live comparison helper.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -10707,7 +10707,12 @@ namespace LaunchPlugin
                 : (data.NewData?.SessionTypeName ?? string.Empty);
             bool debugMaster = IsDebugOnForLogic;
             bool verboseLogs = IsVerboseDebugLoggingOn;
-            _opponentsEngine?.Update(data, pluginManager, isOpponentsEligibleSessionNow, isRaceSessionNow, completedLaps, myPaceSec, pitLossSec, pitTripActive, inLane, trackPct, sessionTimeSec, sessionTimeRemainingSec, verboseLogs, null, BuildRaceContextLeagueClassMatchDelegate());
+            OpponentsEngine.TryGetCheckpointGapSec checkpointGapReader = null;
+            if (_carSaEngine != null)
+            {
+                checkpointGapReader = _carSaEngine.TryGetCheckpointGapSec;
+            }
+            _opponentsEngine?.Update(data, pluginManager, isOpponentsEligibleSessionNow, isRaceSessionNow, completedLaps, myPaceSec, pitLossSec, pitTripActive, inLane, trackPct, sessionTimeSec, sessionTimeRemainingSec, verboseLogs, checkpointGapReader, BuildRaceContextLeagueClassMatchDelegate());
             UpdatePitExitTimeToExitSec(pluginManager, inLane, speedKph);
             int[] carIdxLap = SafeReadIntArray(pluginManager, "DataCorePlugin.GameRawData.Telemetry.CarIdxLap");
             int[] carIdxTrackSurface = SafeReadIntArray(pluginManager, "DataCorePlugin.GameRawData.Telemetry.CarIdxTrackSurface");


### PR DESCRIPTION
### Motivation
- Fix Opponents same-tick checkpoint-gap overwrite where a valid CarSA `TryGetCheckpointGapSec` value could be replaced by native progress fallback during the ordinary `UpdateLiveProperties(...)` refresh. 
- Document the internal runtime correctness fix in the development changelog and repo status to record the wiring change without altering public exports.

### Description
- Changed `LalaLaunch.cs` to capture `CarSA`'s `TryGetCheckpointGapSec` delegate when `_carSaEngine` is available and pass it into `_opponentsEngine.Update(...)` instead of passing `null` for the checkpoint-gap reader. 
- Added a development changelog entry in `Docs/Internal/Development_Changelog.md` describing the fix and its scope. 
- Updated `Docs/RepoStatus.md` to reflect validation of the Opponents CarSA checkpoint seam wiring and note no export-name or property-group changes.

### Testing
- Performed a repository build via `dotnet build` and ran the existing automated unit test suite via `dotnet test`, and the build and tests completed successfully. 
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c65d696a8832fa5c2bcd3ac36a9ba)