### PR TITLE
Add Fuel burn analysis popup: exports, actions, and resettable analysis state

### DIFF
--- a/Docs/Dashboards.md
+++ b/Docs/Dashboards.md
@@ -53,6 +53,12 @@ Dashboard status is plugin-owned:
 
 Dashboards should use those exports only for presentation/visibility. Strategy math, fuel advice, and PreRace logic remain owned by the plugin.
 
+### Strategy Dash fuel-burn analysis binding
+
+A Strategy Dash fuel-burn popup or page can use the plugin-owned `LalaLaunch.Fuel.Burn.DisplayAnalysis` state. Toggle it with `LalaLaunch.BurnDisplayToggle`.
+
+Optional reset actions are `LalaLaunch.BurnAnalysisResetAverages`, `LalaLaunch.BurnAnalysisResetCurrentStint`, `LalaLaunch.BurnAnalysisResetSessionAverage`, and `LalaLaunch.BurnAnalysisResetMaxObserved`. Dashboards should consume `LalaLaunch.Fuel.Burn.Analysis.*` directly because the plugin owns accepted-lap filtering and analysis values.
+
 When manually editing dashboard formulas, use the single plugin-qualified property prefix only (for example `LalaLaunch.PreRace.StatusText`, not `LalaLaunch.LalaLaunch.PreRace.StatusText`).
 
 ### Binding scope in SimHub

--- a/Docs/Fuel_Model.md
+++ b/Docs/Fuel_Model.md
@@ -51,6 +51,8 @@ The fuel model and Strategy work together, but they are not the same thing.
 
 If the live fuel model is still weak, Strategy may still be better served by saved profile values until the live session becomes trustworthy.
 
+For dashboard analysis pages, the plugin publishes `LalaLaunch.Fuel.Burn.Analysis.*` from accepted laps. A popup or page can be toggled with `LalaLaunch.BurnDisplayToggle` through `LalaLaunch.Fuel.Burn.DisplayAnalysis`; dashboards should display those plugin-owned values rather than rebuild accepted-lap filtering or averages.
+
 ## 6. Why users should trust it once learned and locked
 
 Once the model has enough clean data and the related profile values are validated and locked, users should usually trust it.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,5 +1,11 @@
 # Development Changelog
 
+## 2026-06-01 — Fuel burn analysis popup docs + rolling-list synchronization follow-up
+- Classification: **both** (public dashboard binding discoverability plus internal list-read safety hardening).
+- Added short public guidance for `LalaLaunch.Fuel.Burn.DisplayAnalysis`, `LalaLaunch.BurnDisplayToggle`, the optional scoped reset actions, and direct `LalaLaunch.Fuel.Burn.Analysis.*` dashboard consumption.
+- Protected the burn-analysis Avg3/Avg5 rolling list with one dedicated lock across accepted-sample append/trim, averages reset clear, and Avg3/Avg5 property evaluation so a dashboard read cannot race `BurnAnalysisResetAverages`.
+- Preserved available-sample averaging, accepted-lap gating, all other reset semantics, `Fuel.LiveFuelPerLap*`, `Fuel.FuelBurnPredictor*`, Strategy planner, pit/refuel math, dashboard JSON, and XAML.
+
 ## 2026-06-01 — Fuel burn analysis popup plugin exports and actions
 - Classification: **both** (new dashboard-facing plugin export/action contract plus internal Fuel Model observer state).
 - Added presentation-only `Fuel.Burn.DisplayAnalysis` with `LalaLaunch.BurnDisplayToggle`, plus `Fuel.Burn.Analysis.LastLap`, `Avg3`, `Avg5`, `CurrentStint`, `SessionAvg`, `MaxObserved`, and `SampleCount`.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -3,7 +3,7 @@
 ## 2026-06-01 — Fuel burn analysis popup docs + rolling-list synchronization follow-up
 - Classification: **both** (public dashboard binding discoverability plus internal list-read safety hardening).
 - Added short public guidance for `LalaLaunch.Fuel.Burn.DisplayAnalysis`, `LalaLaunch.BurnDisplayToggle`, the optional scoped reset actions, and direct `LalaLaunch.Fuel.Burn.Analysis.*` dashboard consumption.
-- Protected the burn-analysis Avg3/Avg5 rolling list with one dedicated lock across accepted-sample append/trim, averages reset clear, and Avg3/Avg5 property evaluation so a dashboard read cannot race `BurnAnalysisResetAverages`.
+- Protected all `Fuel.Burn.Analysis.*` backing state with one dedicated lock across accepted-sample recording, scoped resets, lifecycle reset, and property evaluation. This keeps `CurrentStint` sum/count, `SessionAvg` sum/count plus `SampleCount`, `MaxObserved`, `LastLap`, and Avg3/Avg5 reads consistent during concurrent dashboard reads and reset actions.
 - Preserved available-sample averaging, accepted-lap gating, all other reset semantics, `Fuel.LiveFuelPerLap*`, `Fuel.FuelBurnPredictor*`, Strategy planner, pit/refuel math, dashboard JSON, and XAML.
 
 ## 2026-06-01 — Fuel burn analysis popup plugin exports and actions

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,5 +1,13 @@
 # Development Changelog
 
+## 2026-06-01 — Fuel burn analysis popup plugin exports and actions
+- Classification: **both** (new dashboard-facing plugin export/action contract plus internal Fuel Model observer state).
+- Added presentation-only `Fuel.Burn.DisplayAnalysis` with `LalaLaunch.BurnDisplayToggle`, plus `Fuel.Burn.Analysis.LastLap`, `Avg3`, `Avg5`, `CurrentStint`, `SessionAvg`, `MaxObserved`, and `SampleCount`.
+- New analysis state observes the existing accepted-fuel-lap insertion seam only: one combined chronological fresh accepted stream across wet/dry, excluding seeded model values and all laps already rejected by existing Fuel Model gating.
+- Added independently scoped reset actions: `LalaLaunch.BurnAnalysisResetAverages`, `LalaLaunch.BurnAnalysisResetCurrentStint`, `LalaLaunch.BurnAnalysisResetSessionAverage`, and `LalaLaunch.BurnAnalysisResetMaxObserved`. Current-stint analysis also clears on the existing confirmed pit-exit edge; normal Fuel Model lifecycle resets clear the full analysis state.
+- Existing accepted-lap logic, `Fuel.LiveFuelPerLap*`, `Fuel.FuelBurnPredictor*`, Strategy planner, pit/refuel math, dashboard JSON, and XAML remain unchanged.
+- Property Snapshot list reviewed: yes; new `Fuel.Burn.*` properties route into the existing Fuel/Strategy group through the existing `Fuel.*` prefix rule.
+
 ## 2026-05-31 — Opponents CarSA checkpoint seam same-tick overwrite fix
 
 - Fixed the ordinary `UpdateLiveProperties(...)` Opponents refresh so it passes the existing CarSA `TryGetCheckpointGapSec` delegate when CarSA is available instead of overwriting a same-tick preferred `Opp.Ahead1` / `Opp.Behind1` checkpoint gap with native progress fallback.

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -3,8 +3,8 @@
 **CANONICAL CONTRACT**
 
 Validated against: HEAD
-Last reviewed: 2026-05-29
-Last updated: 2026-05-29
+Last reviewed: 2026-06-01
+Last updated: 2026-06-01
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -24,6 +24,12 @@ Branch: work
 | --- | --- | --- | --- | --- |
 | Fuel.LiveFuelPerLap | double | Rolling average burn per accepted lap (wet/dry windows, rejects pit/warmup/off-track/outliers). When accepted laps are unavailable, runtime uses profile condition burn before SimHub/DataCore fallback. | 500 ms poll (`UpdateLiveFuelCalcs`). | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2672-L2955】 |
 | Fuel.LiveFuelPerLap_Stable / StableSource / StableConfidence | double/string/double | Smoothed burn chosen from live/profile (deadband hold; confidence aligned to source). | 500 ms poll. | `LalaLaunch.cs` — `UpdateStableFuelPerLap` + `AttachCore`【F:LalaLaunch.cs†L4180-L4254】【F:LalaLaunch.cs†L2672-L2955】 |
+| Fuel.Burn.DisplayAnalysis | bool | Presentation-only Strategy Dash burn-popup/page state. `false` = normal burn display; `true` = analysis display. Toggled by plugin action `LalaLaunch.BurnDisplayToggle`; it is not a fuel-math input. | On action. | `LalaLaunch.cs` — action handler + `AttachCore`. |
+| Fuel.Burn.Analysis.LastLap | double | Most recent fresh accepted fuel-lap burn across wet/dry. Seeded model values and rejected laps are excluded. Zero before the first accepted sample after Fuel Model lifecycle reset. | Per accepted fuel lap. | `LalaLaunch.cs` — accepted-fuel observer + `AttachCore`. |
+| Fuel.Burn.Analysis.Avg3 / Avg5 | double/double | Average of the last 3 / 5 post-reset fresh accepted fuel laps across wet/dry, using the available count when fewer exist. Both publish `0.0` with no post-reset samples and share only their dedicated rolling analysis list. | Per accepted fuel lap or `LalaLaunch.BurnAnalysisResetAverages`. | `LalaLaunch.cs` — accepted-fuel observer + reset action + `AttachCore`. |
+| Fuel.Burn.Analysis.CurrentStint | double | Average fresh accepted fuel burn since confirmed pit exit, normal Fuel Model lifecycle reset, or `LalaLaunch.BurnAnalysisResetCurrentStint`. Publishes `0.0` with no current-stint samples. | Per accepted fuel lap; reset on pit exit/action/lifecycle. | `LalaLaunch.cs` — accepted-fuel observer + pit-exit/reset seams + `AttachCore`. |
+| Fuel.Burn.Analysis.SessionAvg / SampleCount | double/int | Average and count of fresh accepted fuel samples since normal Fuel Model lifecycle reset or `LalaLaunch.BurnAnalysisResetSessionAverage`. They share a dedicated sum/count context and publish `0.0` / `0` safely when empty. | Per accepted fuel lap or session-average reset action/lifecycle. | `LalaLaunch.cs` — accepted-fuel observer + reset action + `AttachCore`. |
+| Fuel.Burn.Analysis.MaxObserved | double | Highest fresh accepted fuel-lap burn since normal Fuel Model lifecycle reset or `LalaLaunch.BurnAnalysisResetMaxObserved`. Publishes `0.0` when empty/reset. | Per accepted fuel lap or max reset action/lifecycle. | `LalaLaunch.cs` — accepted-fuel observer + reset action + `AttachCore`. |
 | Surface.TrackWetness | int | Raw iRacing track wetness (0–3/4 depending on telemetry); informational only. | 500 ms poll. | `LalaLaunch.cs` — `ReadTrackWetness` + `AttachCore`【F:LalaLaunch.cs†L1402-L1426】【F:LalaLaunch.cs†L6095-L6134】【F:LalaLaunch.cs†L2996-L3003】 |
 | Surface.TrackWetnessLabel | string | Human label for track wetness (“Dry/Damp/Light Wet/Mod Wet/Very Wet/Unknown”). | 500 ms poll. | `LalaLaunch.cs` — `MapWetnessLabel` + `AttachCore`【F:LalaLaunch.cs†L1402-L1426】【F:LalaLaunch.cs†L6115-L6134】【F:LalaLaunch.cs†L2996-L3003】 |
 | Fuel.FuelReadyConfidenceThreshold | double | Confidence threshold gating fuel readiness and pit window. | 500 ms poll. | `LalaLaunch.cs` — `GetFuelReadyConfidenceThreshold` + `AttachCore`【F:LalaLaunch.cs†L2672-L2955】 |
@@ -411,6 +417,7 @@ Shift Assist runtime/settings notes:
 | OverlayDashShowLaunchScreen / OverlayDashShowPitLimiter / OverlayDashShowPitScreen / OverlayDashShowRejoinAssist / OverlayDashShowVerboseMessaging / OverlayDashShowRaceFlags / OverlayDashShowRadioMessages / OverlayDashShowTraffic | bool | User visibility toggles for overlay dash. | Per tick. | `LaunchPluginSettings` persisted values + `AttachCore`【F:LalaLaunch.cs†L3197-L3205】 |
 
 Strategy Dash binding note: `StrategyDash.ModeToggle` is a plugin-owned action for Controls & Events / Dash Studio. It toggles the persisted `StrategyDash.AdvancedMode` status only; dashboards use that status for Advanced/Simple presentation and must not move strategy/fuel calculations into dash-side scripts.
+Fuel burn analysis binding note: `BurnDisplayToggle`, `BurnAnalysisResetAverages`, `BurnAnalysisResetCurrentStint`, `BurnAnalysisResetSessionAverage`, and `BurnAnalysisResetMaxObserved` are plugin-owned actions for Controls & Events / Dash Studio. They drive only `Fuel.Burn.DisplayAnalysis` presentation state or the explicitly scoped `Fuel.Burn.Analysis.*` backing group; they do not alter accepted-lap gating, stable fuel, predictor, Strategy planner, or pit/refuel math.
 
 Dark Mode binding warning: When `Use Lovely True Dark` is enabled and Lovely is available, Lovely controls `DarkMode.Active` even if Mode is `Off`, and `BrightnessPct` stays on the user slider value (no auto scaling while Lovely drives). `OpacityPct` remains the final dim value published to dashes. `ModeText` remains tied to `Mode` only (`Off`/`Manual`/`Auto`). `LalaLaunch.ToggleDarkMode` is ignored to prevent conflicting toggles. Do not bind both Lovely and LalaLaunch dark-mode toggles to the same physical input.
 

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -5,6 +5,10 @@ Last updated: 2026-06-01
 Branch: work
 
 ## Current status
+- 2026-06-01: Fuel burn analysis popup review follow-up landed.
+  - Added brief public dashboard/fuel-model guidance for `LalaLaunch.Fuel.Burn.DisplayAnalysis`, `LalaLaunch.BurnDisplayToggle`, optional reset actions, and direct `LalaLaunch.Fuel.Burn.Analysis.*` consumption.
+  - Synchronized the burn-analysis Avg3/Avg5 rolling list with a dedicated lock across accepted-sample append/trim, averages reset, and property reads. Existing partial-window averaging, acceptance logic, other reset semantics, fuel math, Strategy, pit/refuel behavior, dashboard JSON, and XAML remain unchanged.
+
 - 2026-06-01: Fuel burn analysis popup plugin support landed.
   - Added presentation export `Fuel.Burn.DisplayAnalysis`, plugin toggle action `LalaLaunch.BurnDisplayToggle`, and fresh accepted-lap analysis exports `Fuel.Burn.Analysis.LastLap`, `Avg3`, `Avg5`, `CurrentStint`, `SessionAvg`, `MaxObserved`, and `SampleCount`.
   - Added independently scoped reset actions for rolling averages, current stint, session average/sample count, and max observed. `CurrentStint` also resets on the existing confirmed pit-exit edge; Fuel Model lifecycle resets clear all analysis values. Fresh accepted laps only are observed across wet/dry, and seeded race-start model values remain excluded.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -7,7 +7,7 @@ Branch: work
 ## Current status
 - 2026-06-01: Fuel burn analysis popup review follow-up landed.
   - Added brief public dashboard/fuel-model guidance for `LalaLaunch.Fuel.Burn.DisplayAnalysis`, `LalaLaunch.BurnDisplayToggle`, optional reset actions, and direct `LalaLaunch.Fuel.Burn.Analysis.*` consumption.
-  - Synchronized the burn-analysis Avg3/Avg5 rolling list with a dedicated lock across accepted-sample append/trim, averages reset, and property reads. Existing partial-window averaging, acceptance logic, other reset semantics, fuel math, Strategy, pit/refuel behavior, dashboard JSON, and XAML remain unchanged.
+  - Synchronized all `Fuel.Burn.Analysis.*` backing state with one dedicated lock across accepted-sample recording, scoped resets, lifecycle reset, and property reads. Aggregate pairs (`CurrentStint`, `SessionAvg`/`SampleCount`) cannot be observed mid-update or mid-reset. Existing partial-window averaging, reset semantics, acceptance logic, fuel math, Strategy, pit/refuel behavior, dashboard JSON, and XAML remain unchanged.
 
 - 2026-06-01: Fuel burn analysis popup plugin support landed.
   - Added presentation export `Fuel.Burn.DisplayAnalysis`, plugin toggle action `LalaLaunch.BurnDisplayToggle`, and fresh accepted-lap analysis exports `Fuel.Burn.Analysis.LastLap`, `Avg3`, `Avg5`, `CurrentStint`, `SessionAvg`, `MaxObserved`, and `SampleCount`.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,10 +1,15 @@
 # Repo Status
 
 Validated against commit: HEAD
-Last updated: 2026-05-31
+Last updated: 2026-06-01
 Branch: work
 
 ## Current status
+- 2026-06-01: Fuel burn analysis popup plugin support landed.
+  - Added presentation export `Fuel.Burn.DisplayAnalysis`, plugin toggle action `LalaLaunch.BurnDisplayToggle`, and fresh accepted-lap analysis exports `Fuel.Burn.Analysis.LastLap`, `Avg3`, `Avg5`, `CurrentStint`, `SessionAvg`, `MaxObserved`, and `SampleCount`.
+  - Added independently scoped reset actions for rolling averages, current stint, session average/sample count, and max observed. `CurrentStint` also resets on the existing confirmed pit-exit edge; Fuel Model lifecycle resets clear all analysis values. Fresh accepted laps only are observed across wet/dry, and seeded race-start model values remain excluded.
+  - Preserved existing accepted-lap checks, `Fuel.LiveFuelPerLap*`, `Fuel.FuelBurnPredictor*`, Strategy planner, pit/refuel math, dashboard JSON, and XAML. Property Snapshot list reviewed: yes; all new `Fuel.Burn.*` exports resolve through the existing `Fuel.*` prefix into the Fuel/Strategy group.
+
 - 2026-05-31: Opponents CarSA checkpoint seam same-tick overwrite wiring fix validated.
   - The ordinary `UpdateLiveProperties(...)` Opponents refresh now passes the CarSA `TryGetCheckpointGapSec` delegate when CarSA is available, so valid `Opp.Ahead1` / `Opp.Behind1` preferred checkpoint gaps are no longer replaced by same-tick native progress fallback before export.
   - Preserved duplicate refresh timing, native fallback behavior, Opponents ordering, pit-exit behavior, League Class matching, H2H selector ownership, and all export names.

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -209,6 +209,23 @@ The subsystem docs own message-system behavior; dashboards should remain consume
 - `ModeText` is label-only (`ADVANCED` / `SIMPLE`).
 - This mode is a presentation seam only. Strategy, fuel, PreRace, and pit/refuel calculations remain owned by the plugin/subsystems and must not be reimplemented in dashboard expressions.
 
+## Fuel burn analysis popup integration
+### Stable exports for dashboards
+- `LalaLaunch.Fuel.Burn.DisplayAnalysis`
+- `LalaLaunch.Fuel.Burn.Analysis.LastLap`
+- `LalaLaunch.Fuel.Burn.Analysis.Avg3`
+- `LalaLaunch.Fuel.Burn.Analysis.Avg5`
+- `LalaLaunch.Fuel.Burn.Analysis.CurrentStint`
+- `LalaLaunch.Fuel.Burn.Analysis.SessionAvg`
+- `LalaLaunch.Fuel.Burn.Analysis.MaxObserved`
+- `LalaLaunch.Fuel.Burn.Analysis.SampleCount`
+
+### Binding and consumption rules
+- Bind the popup/page toggle through plugin action `LalaLaunch.BurnDisplayToggle`; `Fuel.Burn.DisplayAnalysis=false` means normal fuel-burn display and `true` means analysis display.
+- Optional popup reset controls bind to `LalaLaunch.BurnAnalysisResetAverages`, `LalaLaunch.BurnAnalysisResetCurrentStint`, `LalaLaunch.BurnAnalysisResetSessionAverage`, and `LalaLaunch.BurnAnalysisResetMaxObserved`.
+- Analysis values are plugin-owned fresh accepted-fuel-lap summaries across wet/dry. Dashes must consume them as published and must not rebuild lap acceptance, averaging, session counting, stint reset, or max tracking in expressions.
+- This is an additive analysis/presentation seam only. Existing tactical fuel display and calculation consumers continue to use the existing canonical `Fuel.LiveFuelPerLap_Stable`, `Fuel.Refuel.*`, `Fuel.RequiredBurnToEnd*`, and `Fuel.Pit.*` families as appropriate.
+
 ## Dark Mode integration
 ### Stable exports for dashboards
 - `LalaLaunch.Dash.DarkMode.Mode`

--- a/Docs/Subsystems/Fuel_Model_Subsystem.md
+++ b/Docs/Subsystems/Fuel_Model_Subsystem.md
@@ -1,7 +1,7 @@
 # Fuel Model
 
 Validated against commit: HEAD
-Last updated: 2026-04-22
+Last updated: 2026-06-01
 Branch: work
 
 ## Purpose
@@ -64,6 +64,12 @@ Out of scope:
 - Separate dry and wet accepted-lap windows.
 - Per-session max-burn tracking with spike protection.
 - Seed markers so carry-over baseline values are not immediately evicted on a session transition.
+
+### Fuel burn analysis popup state
+- `Fuel.Burn.Analysis.*` is an additive dashboard-analysis observer fed only by the existing accepted-fuel-lap insertion seam.
+- Analysis samples are one combined chronological fresh accepted-lap stream across wet and dry; seeded profile/race-start model values are intentionally excluded.
+- Independently resettable backing groups preserve action semantics: Avg3/Avg5 rolling list, current-stint sum/count, session-average sum/count (also `SampleCount`), and max-observed value. `LastLap` updates on every accepted fuel lap and has no manual reset action.
+- `CurrentStint` resets on the existing confirmed pit-exit edge. Temporary telemetry gaps retain the last accepted analysis state, matching the broader Fuel Model lifecycle behavior.
 
 ### Stable burn state
 - A continuously evaluated candidate burn.
@@ -187,6 +193,8 @@ Typical states include:
 ### Core exports
 The full authoritative export list lives in `Docs/Internal/SimHubParameterInventory.md`. The key Fuel Model families are:
 - `Fuel.LiveFuelPerLap*`
+- `Fuel.Burn.DisplayAnalysis` (presentation-only popup/page state toggled by `LalaLaunch.BurnDisplayToggle`)
+- `Fuel.Burn.Analysis.*` (fresh accepted-lap popup analysis: `LastLap`, `Avg3`, `Avg5`, `CurrentStint`, `SessionAvg`, `MaxObserved`, `SampleCount`)
 - `Fuel.LiveLapsRemainingInRace*`
 - `Fuel.LapsRemainingInTank`
 - `Fuel.RequiredBurnToEnd*`
@@ -254,7 +262,15 @@ Runtime recovery now distinguishes between:
 Planner-safe targeted recovery is intended to rebuild live-cap/runtime truth without silently clearing Strategy manual overrides or preset intent.
 Manual recovery may short-circuit on planner-safe success only while an active live session is present; outside active live session, manual reset continues into the broad reset path.
 
-Driving → Race transitions can seed race state from the just-learned baseline instead of forcing a full cold start.
+Driving → Race transitions can seed race state from the just-learned baseline instead of forcing a full cold start. Those seeds intentionally do not enter `Fuel.Burn.Analysis.*`, which remains fresh-sample-only.
+
+Fuel-burn popup analysis reset rules:
+- normal Fuel Model lifecycle reset clears `LastLap`, Avg3/Avg5, `CurrentStint`, `SessionAvg`, `SampleCount`, and `MaxObserved`,
+- confirmed pit exit clears only `CurrentStint`,
+- `LalaLaunch.BurnAnalysisResetAverages` clears only Avg3/Avg5,
+- `LalaLaunch.BurnAnalysisResetCurrentStint` clears only `CurrentStint`,
+- `LalaLaunch.BurnAnalysisResetSessionAverage` clears only `SessionAvg` and `SampleCount`,
+- `LalaLaunch.BurnAnalysisResetMaxObserved` clears only `MaxObserved`.
 
 ## Failure modes / edge cases
 - **Replay timing anomalies:** acceptance/projection behavior may need log verification.

--- a/Docs/Subsystems/Fuel_Model_Subsystem.md
+++ b/Docs/Subsystems/Fuel_Model_Subsystem.md
@@ -69,6 +69,7 @@ Out of scope:
 - `Fuel.Burn.Analysis.*` is an additive dashboard-analysis observer fed only by the existing accepted-fuel-lap insertion seam.
 - Analysis samples are one combined chronological fresh accepted-lap stream across wet and dry; seeded profile/race-start model values are intentionally excluded.
 - Independently resettable backing groups preserve action semantics: Avg3/Avg5 rolling list, current-stint sum/count, session-average sum/count (also `SampleCount`), and max-observed value. `LastLap` updates on every accepted fuel lap and has no manual reset action.
+- One dedicated burn-analysis lock protects accepted-sample recording, scoped resets, lifecycle reset, and property reads so aggregate pairs cannot be observed mid-update or mid-reset.
 - `CurrentStint` resets on the existing confirmed pit-exit edge. Temporary telemetry gaps retain the last accepted analysis state, matching the broader Fuel Model lifecycle behavior.
 
 ### Stable burn state

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -997,8 +997,8 @@ namespace LaunchPlugin
 
         public bool Fuel_Burn_DisplayAnalysis { get; private set; }
         public double Fuel_Burn_Analysis_LastLap => _burnAnalysisLastLap;
-        public double Fuel_Burn_Analysis_Avg3 => GetRollingAverage(_burnAnalysisRecentAcceptedFuelLaps, 3) ?? 0.0;
-        public double Fuel_Burn_Analysis_Avg5 => GetRollingAverage(_burnAnalysisRecentAcceptedFuelLaps, 5) ?? 0.0;
+        public double Fuel_Burn_Analysis_Avg3 => AverageAvailableRecentSamples(_burnAnalysisRecentAcceptedFuelLaps, 3);
+        public double Fuel_Burn_Analysis_Avg5 => AverageAvailableRecentSamples(_burnAnalysisRecentAcceptedFuelLaps, 5);
         public double Fuel_Burn_Analysis_CurrentStint => _burnAnalysisCurrentStintCount > 0 ? _burnAnalysisCurrentStintSum / _burnAnalysisCurrentStintCount : 0.0;
         public double Fuel_Burn_Analysis_SessionAvg => _burnAnalysisSessionCount > 0 ? _burnAnalysisSessionSum / _burnAnalysisSessionCount : 0.0;
         public double Fuel_Burn_Analysis_MaxObserved => _burnAnalysisMaxObserved;
@@ -19829,6 +19829,23 @@ namespace LaunchPlugin
             LiveFuelPerLap_Stable = _stableFuelPerLap;
             LiveFuelPerLap_StableSource = _stableFuelPerLapSource;
             LiveFuelPerLap_StableConfidence = _stableFuelPerLapConfidence;
+        }
+
+        private static double AverageAvailableRecentSamples(List<double> samples, int requestedCount)
+        {
+            if (samples == null || samples.Count == 0 || requestedCount <= 0)
+            {
+                return 0.0;
+            }
+
+            int sampleCount = Math.Min(samples.Count, requestedCount);
+            double sum = 0.0;
+            for (int i = samples.Count - sampleCount; i < samples.Count; i++)
+            {
+                sum += samples[i];
+            }
+
+            return sum / sampleCount;
         }
 
         private static double? GetRollingAverage(List<double> samples, int sampleCount)

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -987,7 +987,7 @@ namespace LaunchPlugin
         private const int FuelPersistMinLaps = 2; // guard against early garbage in live persistence
 
         // Fuel burn analysis is a fresh accepted-lap observer only. It intentionally does not consume seeded model windows.
-        private readonly object _burnAnalysisRecentAcceptedFuelLapsLock = new object();
+        private readonly object _burnAnalysisLock = new object();
         private readonly List<double> _burnAnalysisRecentAcceptedFuelLaps = new List<double>();
         private double _burnAnalysisLastLap;
         private double _burnAnalysisCurrentStintSum;
@@ -997,13 +997,13 @@ namespace LaunchPlugin
         private double _burnAnalysisMaxObserved;
 
         public bool Fuel_Burn_DisplayAnalysis { get; private set; }
-        public double Fuel_Burn_Analysis_LastLap => _burnAnalysisLastLap;
+        public double Fuel_Burn_Analysis_LastLap => GetBurnAnalysisLastLap();
         public double Fuel_Burn_Analysis_Avg3 => GetBurnAnalysisAverageAvailableRecentSamples(3);
         public double Fuel_Burn_Analysis_Avg5 => GetBurnAnalysisAverageAvailableRecentSamples(5);
-        public double Fuel_Burn_Analysis_CurrentStint => _burnAnalysisCurrentStintCount > 0 ? _burnAnalysisCurrentStintSum / _burnAnalysisCurrentStintCount : 0.0;
-        public double Fuel_Burn_Analysis_SessionAvg => _burnAnalysisSessionCount > 0 ? _burnAnalysisSessionSum / _burnAnalysisSessionCount : 0.0;
-        public double Fuel_Burn_Analysis_MaxObserved => _burnAnalysisMaxObserved;
-        public int Fuel_Burn_Analysis_SampleCount => _burnAnalysisSessionCount;
+        public double Fuel_Burn_Analysis_CurrentStint => GetBurnAnalysisCurrentStint();
+        public double Fuel_Burn_Analysis_SessionAvg => GetBurnAnalysisSessionAvg();
+        public double Fuel_Burn_Analysis_MaxObserved => GetBurnAnalysisMaxObserved();
+        public int Fuel_Burn_Analysis_SampleCount => GetBurnAnalysisSampleCount();
 
         private double _avgDryFuelPerLap = 0.0;
         private double _avgWetFuelPerLap = 0.0;
@@ -3161,29 +3161,29 @@ namespace LaunchPlugin
 
         private void RecordAcceptedBurnAnalysisSample(double fuelUsed)
         {
-            _burnAnalysisLastLap = fuelUsed;
-            lock (_burnAnalysisRecentAcceptedFuelLapsLock)
+            lock (_burnAnalysisLock)
             {
+                _burnAnalysisLastLap = fuelUsed;
                 _burnAnalysisRecentAcceptedFuelLaps.Add(fuelUsed);
                 while (_burnAnalysisRecentAcceptedFuelLaps.Count > FuelWindowSize)
                 {
                     _burnAnalysisRecentAcceptedFuelLaps.RemoveAt(0);
                 }
-            }
 
-            _burnAnalysisCurrentStintSum += fuelUsed;
-            _burnAnalysisCurrentStintCount++;
-            _burnAnalysisSessionSum += fuelUsed;
-            _burnAnalysisSessionCount++;
-            if (fuelUsed > _burnAnalysisMaxObserved)
-            {
-                _burnAnalysisMaxObserved = fuelUsed;
+                _burnAnalysisCurrentStintSum += fuelUsed;
+                _burnAnalysisCurrentStintCount++;
+                _burnAnalysisSessionSum += fuelUsed;
+                _burnAnalysisSessionCount++;
+                if (fuelUsed > _burnAnalysisMaxObserved)
+                {
+                    _burnAnalysisMaxObserved = fuelUsed;
+                }
             }
         }
 
         private void ResetBurnAnalysisAverages()
         {
-            lock (_burnAnalysisRecentAcceptedFuelLapsLock)
+            lock (_burnAnalysisLock)
             {
                 _burnAnalysisRecentAcceptedFuelLaps.Clear();
             }
@@ -3191,28 +3191,42 @@ namespace LaunchPlugin
 
         private void ResetBurnAnalysisCurrentStint()
         {
-            _burnAnalysisCurrentStintSum = 0.0;
-            _burnAnalysisCurrentStintCount = 0;
+            lock (_burnAnalysisLock)
+            {
+                _burnAnalysisCurrentStintSum = 0.0;
+                _burnAnalysisCurrentStintCount = 0;
+            }
         }
 
         private void ResetBurnAnalysisSessionAverage()
         {
-            _burnAnalysisSessionSum = 0.0;
-            _burnAnalysisSessionCount = 0;
+            lock (_burnAnalysisLock)
+            {
+                _burnAnalysisSessionSum = 0.0;
+                _burnAnalysisSessionCount = 0;
+            }
         }
 
         private void ResetBurnAnalysisMaxObserved()
         {
-            _burnAnalysisMaxObserved = 0.0;
+            lock (_burnAnalysisLock)
+            {
+                _burnAnalysisMaxObserved = 0.0;
+            }
         }
 
         private void ResetBurnAnalysisForFuelModelLifecycle()
         {
-            _burnAnalysisLastLap = 0.0;
-            ResetBurnAnalysisAverages();
-            ResetBurnAnalysisCurrentStint();
-            ResetBurnAnalysisSessionAverage();
-            ResetBurnAnalysisMaxObserved();
+            lock (_burnAnalysisLock)
+            {
+                _burnAnalysisLastLap = 0.0;
+                _burnAnalysisRecentAcceptedFuelLaps.Clear();
+                _burnAnalysisCurrentStintSum = 0.0;
+                _burnAnalysisCurrentStintCount = 0;
+                _burnAnalysisSessionSum = 0.0;
+                _burnAnalysisSessionCount = 0;
+                _burnAnalysisMaxObserved = 0.0;
+            }
         }
 
         private void ResetLiveFuelModelForNewSession(string newSessionType, bool applySeeds)
@@ -19838,11 +19852,51 @@ namespace LaunchPlugin
             LiveFuelPerLap_StableConfidence = _stableFuelPerLapConfidence;
         }
 
+        private double GetBurnAnalysisLastLap()
+        {
+            lock (_burnAnalysisLock)
+            {
+                return _burnAnalysisLastLap;
+            }
+        }
+
         private double GetBurnAnalysisAverageAvailableRecentSamples(int requestedCount)
         {
-            lock (_burnAnalysisRecentAcceptedFuelLapsLock)
+            lock (_burnAnalysisLock)
             {
                 return AverageAvailableRecentSamples(_burnAnalysisRecentAcceptedFuelLaps, requestedCount);
+            }
+        }
+
+        private double GetBurnAnalysisCurrentStint()
+        {
+            lock (_burnAnalysisLock)
+            {
+                return _burnAnalysisCurrentStintCount > 0 ? _burnAnalysisCurrentStintSum / _burnAnalysisCurrentStintCount : 0.0;
+            }
+        }
+
+        private double GetBurnAnalysisSessionAvg()
+        {
+            lock (_burnAnalysisLock)
+            {
+                return _burnAnalysisSessionCount > 0 ? _burnAnalysisSessionSum / _burnAnalysisSessionCount : 0.0;
+            }
+        }
+
+        private double GetBurnAnalysisMaxObserved()
+        {
+            lock (_burnAnalysisLock)
+            {
+                return _burnAnalysisMaxObserved;
+            }
+        }
+
+        private int GetBurnAnalysisSampleCount()
+        {
+            lock (_burnAnalysisLock)
+            {
+                return _burnAnalysisSessionCount;
             }
         }
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -987,6 +987,7 @@ namespace LaunchPlugin
         private const int FuelPersistMinLaps = 2; // guard against early garbage in live persistence
 
         // Fuel burn analysis is a fresh accepted-lap observer only. It intentionally does not consume seeded model windows.
+        private readonly object _burnAnalysisRecentAcceptedFuelLapsLock = new object();
         private readonly List<double> _burnAnalysisRecentAcceptedFuelLaps = new List<double>();
         private double _burnAnalysisLastLap;
         private double _burnAnalysisCurrentStintSum;
@@ -997,8 +998,8 @@ namespace LaunchPlugin
 
         public bool Fuel_Burn_DisplayAnalysis { get; private set; }
         public double Fuel_Burn_Analysis_LastLap => _burnAnalysisLastLap;
-        public double Fuel_Burn_Analysis_Avg3 => AverageAvailableRecentSamples(_burnAnalysisRecentAcceptedFuelLaps, 3);
-        public double Fuel_Burn_Analysis_Avg5 => AverageAvailableRecentSamples(_burnAnalysisRecentAcceptedFuelLaps, 5);
+        public double Fuel_Burn_Analysis_Avg3 => GetBurnAnalysisAverageAvailableRecentSamples(3);
+        public double Fuel_Burn_Analysis_Avg5 => GetBurnAnalysisAverageAvailableRecentSamples(5);
         public double Fuel_Burn_Analysis_CurrentStint => _burnAnalysisCurrentStintCount > 0 ? _burnAnalysisCurrentStintSum / _burnAnalysisCurrentStintCount : 0.0;
         public double Fuel_Burn_Analysis_SessionAvg => _burnAnalysisSessionCount > 0 ? _burnAnalysisSessionSum / _burnAnalysisSessionCount : 0.0;
         public double Fuel_Burn_Analysis_MaxObserved => _burnAnalysisMaxObserved;
@@ -3161,10 +3162,13 @@ namespace LaunchPlugin
         private void RecordAcceptedBurnAnalysisSample(double fuelUsed)
         {
             _burnAnalysisLastLap = fuelUsed;
-            _burnAnalysisRecentAcceptedFuelLaps.Add(fuelUsed);
-            while (_burnAnalysisRecentAcceptedFuelLaps.Count > FuelWindowSize)
+            lock (_burnAnalysisRecentAcceptedFuelLapsLock)
             {
-                _burnAnalysisRecentAcceptedFuelLaps.RemoveAt(0);
+                _burnAnalysisRecentAcceptedFuelLaps.Add(fuelUsed);
+                while (_burnAnalysisRecentAcceptedFuelLaps.Count > FuelWindowSize)
+                {
+                    _burnAnalysisRecentAcceptedFuelLaps.RemoveAt(0);
+                }
             }
 
             _burnAnalysisCurrentStintSum += fuelUsed;
@@ -3179,7 +3183,10 @@ namespace LaunchPlugin
 
         private void ResetBurnAnalysisAverages()
         {
-            _burnAnalysisRecentAcceptedFuelLaps.Clear();
+            lock (_burnAnalysisRecentAcceptedFuelLapsLock)
+            {
+                _burnAnalysisRecentAcceptedFuelLaps.Clear();
+            }
         }
 
         private void ResetBurnAnalysisCurrentStint()
@@ -19829,6 +19836,14 @@ namespace LaunchPlugin
             LiveFuelPerLap_Stable = _stableFuelPerLap;
             LiveFuelPerLap_StableSource = _stableFuelPerLapSource;
             LiveFuelPerLap_StableConfidence = _stableFuelPerLapConfidence;
+        }
+
+        private double GetBurnAnalysisAverageAvailableRecentSamples(int requestedCount)
+        {
+            lock (_burnAnalysisRecentAcceptedFuelLapsLock)
+            {
+                return AverageAvailableRecentSamples(_burnAnalysisRecentAcceptedFuelLaps, requestedCount);
+            }
         }
 
         private static double AverageAvailableRecentSamples(List<double> samples, int requestedCount)

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -172,6 +172,31 @@ namespace LaunchPlugin
             ManualRecoveryReset(reason);
         }
 
+        public void BurnDisplayToggle()
+        {
+            Fuel_Burn_DisplayAnalysis = !Fuel_Burn_DisplayAnalysis;
+        }
+
+        public void BurnAnalysisResetAverages()
+        {
+            ResetBurnAnalysisAverages();
+        }
+
+        public void BurnAnalysisResetCurrentStint()
+        {
+            ResetBurnAnalysisCurrentStint();
+        }
+
+        public void BurnAnalysisResetSessionAverage()
+        {
+            ResetBurnAnalysisSessionAverage();
+        }
+
+        public void BurnAnalysisResetMaxObserved()
+        {
+            ResetBurnAnalysisMaxObserved();
+        }
+
 
         // Exposed dash mode value: 0,1,2
         public int DeclutterMode { get; private set; } = 0;
@@ -960,6 +985,24 @@ namespace LaunchPlugin
         private readonly List<double> _recentWetFuelLaps = new List<double>();
         private const int FuelWindowSize = 5; // keep last N valid laps per mode
         private const int FuelPersistMinLaps = 2; // guard against early garbage in live persistence
+
+        // Fuel burn analysis is a fresh accepted-lap observer only. It intentionally does not consume seeded model windows.
+        private readonly List<double> _burnAnalysisRecentAcceptedFuelLaps = new List<double>();
+        private double _burnAnalysisLastLap;
+        private double _burnAnalysisCurrentStintSum;
+        private int _burnAnalysisCurrentStintCount;
+        private double _burnAnalysisSessionSum;
+        private int _burnAnalysisSessionCount;
+        private double _burnAnalysisMaxObserved;
+
+        public bool Fuel_Burn_DisplayAnalysis { get; private set; }
+        public double Fuel_Burn_Analysis_LastLap => _burnAnalysisLastLap;
+        public double Fuel_Burn_Analysis_Avg3 => GetRollingAverage(_burnAnalysisRecentAcceptedFuelLaps, 3) ?? 0.0;
+        public double Fuel_Burn_Analysis_Avg5 => GetRollingAverage(_burnAnalysisRecentAcceptedFuelLaps, 5) ?? 0.0;
+        public double Fuel_Burn_Analysis_CurrentStint => _burnAnalysisCurrentStintCount > 0 ? _burnAnalysisCurrentStintSum / _burnAnalysisCurrentStintCount : 0.0;
+        public double Fuel_Burn_Analysis_SessionAvg => _burnAnalysisSessionCount > 0 ? _burnAnalysisSessionSum / _burnAnalysisSessionCount : 0.0;
+        public double Fuel_Burn_Analysis_MaxObserved => _burnAnalysisMaxObserved;
+        public int Fuel_Burn_Analysis_SampleCount => _burnAnalysisSessionCount;
 
         private double _avgDryFuelPerLap = 0.0;
         private double _avgWetFuelPerLap = 0.0;
@@ -3115,9 +3158,60 @@ namespace LaunchPlugin
             _lastProjectionLapSecondsUsed = 0.0;
         }
 
+        private void RecordAcceptedBurnAnalysisSample(double fuelUsed)
+        {
+            _burnAnalysisLastLap = fuelUsed;
+            _burnAnalysisRecentAcceptedFuelLaps.Add(fuelUsed);
+            while (_burnAnalysisRecentAcceptedFuelLaps.Count > FuelWindowSize)
+            {
+                _burnAnalysisRecentAcceptedFuelLaps.RemoveAt(0);
+            }
+
+            _burnAnalysisCurrentStintSum += fuelUsed;
+            _burnAnalysisCurrentStintCount++;
+            _burnAnalysisSessionSum += fuelUsed;
+            _burnAnalysisSessionCount++;
+            if (fuelUsed > _burnAnalysisMaxObserved)
+            {
+                _burnAnalysisMaxObserved = fuelUsed;
+            }
+        }
+
+        private void ResetBurnAnalysisAverages()
+        {
+            _burnAnalysisRecentAcceptedFuelLaps.Clear();
+        }
+
+        private void ResetBurnAnalysisCurrentStint()
+        {
+            _burnAnalysisCurrentStintSum = 0.0;
+            _burnAnalysisCurrentStintCount = 0;
+        }
+
+        private void ResetBurnAnalysisSessionAverage()
+        {
+            _burnAnalysisSessionSum = 0.0;
+            _burnAnalysisSessionCount = 0;
+        }
+
+        private void ResetBurnAnalysisMaxObserved()
+        {
+            _burnAnalysisMaxObserved = 0.0;
+        }
+
+        private void ResetBurnAnalysisForFuelModelLifecycle()
+        {
+            _burnAnalysisLastLap = 0.0;
+            ResetBurnAnalysisAverages();
+            ResetBurnAnalysisCurrentStint();
+            ResetBurnAnalysisSessionAverage();
+            ResetBurnAnalysisMaxObserved();
+        }
+
         private void ResetLiveFuelModelForNewSession(string newSessionType, bool applySeeds)
         {
             ResetProjectionFallbackState();
+            ResetBurnAnalysisForFuelModelLifecycle();
 
             // Clear per-lap / model state
             ResetLiveMaxFuelTracking();
@@ -4247,6 +4341,7 @@ namespace LaunchPlugin
                             _freshDrySamplesInWindow++;
 
                         window.Add(fuelUsed);
+                        RecordAcceptedBurnAnalysisSample(fuelUsed);
                         SessionSummaryRuntime.OnValidFuelLap(_currentSessionToken, fuelUsed);
                         while (window.Count > FuelWindowSize)
                         {
@@ -7187,6 +7282,11 @@ namespace LaunchPlugin
             this.AddAction("Pit.FuelRemove", (a, b) => PitFuelRemove1());
             this.AddAction("PrimaryDashMode", (a, b) => PrimaryDashMode());
             this.AddAction("StrategyDash.ModeToggle", (a, b) => StrategyDashModeToggle());
+            this.AddAction("BurnDisplayToggle", (a, b) => BurnDisplayToggle());
+            this.AddAction("BurnAnalysisResetAverages", (a, b) => BurnAnalysisResetAverages());
+            this.AddAction("BurnAnalysisResetCurrentStint", (a, b) => BurnAnalysisResetCurrentStint());
+            this.AddAction("BurnAnalysisResetSessionAverage", (a, b) => BurnAnalysisResetSessionAverage());
+            this.AddAction("BurnAnalysisResetMaxObserved", (a, b) => BurnAnalysisResetMaxObserved());
             this.AddAction("DeclutterMode", (a, b) => DeclutterMode0());
             this.AddAction("ToggleDarkMode", (a, b) => ToggleDarkMode());
             this.AddAction("EventMarker", (a, b) => EventMarker());
@@ -7309,6 +7409,14 @@ namespace LaunchPlugin
             AttachCore("Fuel.LiveFuelPerLap_Stable", () => LiveFuelPerLap_Stable);
             AttachCore("Fuel.LiveFuelPerLap_StableSource", () => LiveFuelPerLap_StableSource);
             AttachCore("Fuel.LiveFuelPerLap_StableConfidence", () => LiveFuelPerLap_StableConfidence);
+            AttachCore("Fuel.Burn.DisplayAnalysis", () => Fuel_Burn_DisplayAnalysis);
+            AttachCore("Fuel.Burn.Analysis.LastLap", () => Fuel_Burn_Analysis_LastLap);
+            AttachCore("Fuel.Burn.Analysis.Avg3", () => Fuel_Burn_Analysis_Avg3);
+            AttachCore("Fuel.Burn.Analysis.Avg5", () => Fuel_Burn_Analysis_Avg5);
+            AttachCore("Fuel.Burn.Analysis.CurrentStint", () => Fuel_Burn_Analysis_CurrentStint);
+            AttachCore("Fuel.Burn.Analysis.SessionAvg", () => Fuel_Burn_Analysis_SessionAvg);
+            AttachCore("Fuel.Burn.Analysis.MaxObserved", () => Fuel_Burn_Analysis_MaxObserved);
+            AttachCore("Fuel.Burn.Analysis.SampleCount", () => Fuel_Burn_Analysis_SampleCount);
             AttachCore("Surface.TrackWetness", () => TrackWetness);
             AttachCore("Surface.TrackWetnessLabel", () => TrackWetnessLabel);
             AttachCore("Fuel.FuelReadyConfidenceThreshold", () => GetFuelReadyConfidenceThreshold());
@@ -10936,6 +11044,7 @@ namespace LaunchPlugin
 
             if (pitExitEdge)
             {
+                ResetBurnAnalysisCurrentStint();
                 _tyreLearnLastPitExitSessionTimeSec = sessionTime;
                 _opponentsEngine?.NotifyPitExitLine(completedLaps, sessionTime, trackPct);
                 // LogPitExitPitOutSnapshot(sessionTime, completedLaps + 1, pitTripActive);


### PR DESCRIPTION
### Motivation
- Provide a presentation-only fuel-burn analysis popup/page so dashboards can show recent accepted-lap analysis without touching core fuel math. 
- Capture fresh accepted-lap samples (across wet/dry) for rolling Avg3/Avg5, current-stint, session average/count, last-lap, and max-observed while excluding seeded model values. 
- Expose explicit, independently scoped reset actions and ensure the feature is non-invasive to existing Fuel Model outputs and pit/refuel calculations.

### Description
- Added plugin actions `BurnDisplayToggle`, `BurnAnalysisResetAverages`, `BurnAnalysisResetCurrentStint`, `BurnAnalysisResetSessionAverage`, and `BurnAnalysisResetMaxObserved` and wired them into `AddAction(...)` handlers. 
- Implemented in-plugin analysis state and APIs: backing lists/fields (`_burnAnalysisRecentAcceptedFuelLaps`, `_burnAnalysisLastLap`, `_burnAnalysisCurrentStintSum`/count, `_burnAnalysisSessionSum`/count, `_burnAnalysisMaxObserved`), sample recorder `RecordAcceptedBurnAnalysisSample(...)`, reset helpers, and lifecycle/pit-exit reset hooks. 
- Published new SimHub exports via `AttachCore(...)`: `Fuel.Burn.DisplayAnalysis`, `Fuel.Burn.Analysis.LastLap`, `Fuel.Burn.Analysis.Avg3`, `Fuel.Burn.Analysis.Avg5`, `Fuel.Burn.Analysis.CurrentStint`, `Fuel.Burn.Analysis.SessionAvg`, `Fuel.Burn.Analysis.MaxObserved`, and `Fuel.Burn.Analysis.SampleCount`. 
- Updated documentation and inventories to reflect the new exports and binding rules (`Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`, `Docs/Subsystems/Dash_Integration.md`, `Docs/Subsystems/Fuel_Model_Subsystem.md`).

### Testing
- Compiled the solution and ran the existing automated unit and integration test suite against the modified code with no failures. 
- Verified automated export/parameter inventory validation and that the new `Fuel.Burn.*` exports are attached and reachable by the existing export snapshot checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4c5a009c832fbcaa5e7a6be2b661)