### PR TITLE
Add League Race settings header state

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,8 @@
+## 2026-06-24 — Settings League Race header state
+- Classification: **both** (driver-facing Settings UI readability plus internal docs alignment; no dashboard JSON/export changes).
+- Settings now binds the collapsed League Race expander header to a UI-only `LEAGUE RACE - OFF/ACTIVE/WARNING` status that mirrors the Overview practical state model: disabled is OFF; enabled and usable is ACTIVE; CSV/config/manual-override/player-resolution problems are WARNING, with zero-row warnings limited to CSV-backed modes and no-live-session waiting treated as non-fault.
+- Header colour/style remains unchanged; no League Class resolver semantics, SimHub exports, dashboard JSON, Overview logic, or cohort/ranking behavior changed. Property Snapshot list reviewed: yes; no SimHub exports/properties changed.
+
 ## 2026-06-24 — PR #844 remaining-time sentinel/reconnect fallback fix
 - Classification: **both** (driver/dash-visible finish correctness plus internal finish fallback clarification; no export names, settings, dashboard JSON, fuel, pit, opponent, H2H, League Class, CarSA, or Strategy behavior changes).
 - Corrected missing-SessionState finish-flag authority so `SessionTimeRemain == -1` (and NaN/Infinity/negative sentinels) is treated as no timed-race authority, allowing the lap-limited/no-time-authority completed-lap fallback instead of blocking it as timed authority.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,7 @@
+- 2026-06-24 Settings League Race header state landed:
+  - collapsed Settings League Race expander text now exposes `LEAGUE RACE - OFF`, `LEAGUE RACE - ACTIVE`, or `LEAGUE RACE - WARNING` using the same practical state model as Overview;
+  - zero loaded/valid row warnings remain limited to CSV-backed modes, invalid manual override stays WARNING, and no-live-session waiting remains non-fault;
+  - header colour/style, League Class resolver semantics, SimHub exports, dashboard JSON, Overview logic, and cohort/ranking behavior are unchanged. Property Snapshot list reviewed: yes; no export/property changes.
 - 2026-06-24 PR #844 remaining-time sentinel/reconnect fallback fix landed:
   - `SessionTimeRemain == -1` plus NaN/Infinity/other negative sentinels now counts as no timed-race authority for missing-SessionState finish-flag trust, so completed-lap fallback remains available for lap-limited/no-time-authority paths;
   - missing-SessionState timed authority is valid only for finite non-negative remaining time, and after-zero proof can come from either `_timerZeroSeen` or current `SessionTimeRemain <= 0`, preserving reconnect/startup after-zero finish capture;

--- a/Docs/Subsystems/League_Class_System.md
+++ b/Docs/Subsystems/League_Class_System.md
@@ -62,6 +62,7 @@ Contract notes:
 - CSV load path + reload flow.
 - Compact CSV status line (`Status | Rows | Valid | Invalid | Duplicates`).
 - Warning-state helper text for CSV/mapping issues.
+- Collapsed Settings header text mirrors the Overview practical state as `LEAGUE RACE - OFF`, `LEAGUE RACE - ACTIVE`, or `LEAGUE RACE - WARNING` without changing the expander/header colour or style.
 - Auto-detect preview for player effective class.
 - Manual override editing for player class only.
 - `LeagueClass.ToggleEnabled` toggle behavior with enable guard.

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -58,7 +58,7 @@ The current top-level plugin order is:
 
 Important workflow rules:
 
-- **Overview** is the landing tab for quick orientation, links, update status, current Monitor System health text, and League Class OFF/ACTIVE/WARNING status. The Restart Plugin action is danger-styled because it manually re-arms runtime systems.
+- **Overview** is the landing tab for quick orientation, links, update status, current Monitor System health text, and League Class OFF/ACTIVE/WARNING status. The collapsed **Settings → League Race** header also shows `LEAGUE RACE - OFF`, `LEAGUE RACE - ACTIVE`, or `LEAGUE RACE - WARNING` so the state is visible without expanding the section. The Restart Plugin action is danger-styled because it manually re-arms runtime systems.
 - The main planning tab is **Strategy**, not Fuel.
 - There is **no separate Presets tab**.
 - Presets are managed from **Strategy** using the **`Presets...`** modal flow.

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -190,7 +190,7 @@
 
             
             
-            <Expander Header="League Race"
+            <Expander Header="{Binding LeagueRaceSettingsHeaderText}"
                       Margin="0,0,0,10"
                       IsExpanded="False">
                 <StackPanel Margin="0,10,0,0">

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -6722,6 +6722,7 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(LeagueClassPlayerColourHexEditorText));
             OnPropertyChanged(nameof(LeagueClassHelperHasWarning));
             OnPropertyChanged(nameof(LeagueClassHelperForeground));
+            OnPropertyChanged(nameof(LeagueRaceSettingsHeaderText));
             OnPropertyChanged(nameof(LeagueClassShowCsvSection));
             OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
         }
@@ -6749,6 +6750,7 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(Settings));
             OnPropertyChanged(nameof(LeagueClassHelperHasWarning));
             OnPropertyChanged(nameof(LeagueClassHelperForeground));
+            OnPropertyChanged(nameof(LeagueRaceSettingsHeaderText));
         }
 
         private void ReloadLeagueClassConfigForEnableIfNeeded()
@@ -6817,10 +6819,10 @@ namespace LaunchPlugin
         }
 
         public bool LeagueClassPlayerOverrideIsAutoDetect => Settings == null || Settings.LeagueClassPlayerOverrideMode != 1;
-        public string LeagueClassPlayerClassNameEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewClassName : (Settings?.LeagueClassPlayerOverrideClassName ?? string.Empty); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null) Settings.LeagueClassPlayerOverrideClassName = value; } }
-        public string LeagueClassPlayerShortNameEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewShortName : (Settings?.LeagueClassPlayerOverrideShortName ?? string.Empty); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null) Settings.LeagueClassPlayerOverrideShortName = value; } }
-        public string LeagueClassPlayerRankEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewRank.ToString(CultureInfo.InvariantCulture) : (Settings?.LeagueClassPlayerOverrideRank.ToString(CultureInfo.InvariantCulture) ?? "0"); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed)) Settings.LeagueClassPlayerOverrideRank = parsed; } }
-        public string LeagueClassPlayerColourHexEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewColourHex : (Settings?.LeagueClassPlayerOverrideColourHex ?? string.Empty); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null) Settings.LeagueClassPlayerOverrideColourHex = value; } }
+        public string LeagueClassPlayerClassNameEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewClassName : (Settings?.LeagueClassPlayerOverrideClassName ?? string.Empty); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null) { Settings.LeagueClassPlayerOverrideClassName = value; NotifyLeagueClassUiStatusChanged(); } } }
+        public string LeagueClassPlayerShortNameEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewShortName : (Settings?.LeagueClassPlayerOverrideShortName ?? string.Empty); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null) { Settings.LeagueClassPlayerOverrideShortName = value; NotifyLeagueClassUiStatusChanged(); } } }
+        public string LeagueClassPlayerRankEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewRank.ToString(CultureInfo.InvariantCulture) : (Settings?.LeagueClassPlayerOverrideRank.ToString(CultureInfo.InvariantCulture) ?? "0"); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed)) { Settings.LeagueClassPlayerOverrideRank = parsed; NotifyLeagueClassUiStatusChanged(); } } }
+        public string LeagueClassPlayerColourHexEditorText { get => LeagueClassPlayerOverrideIsAutoDetect ? LeagueClassPlayerPreviewColourHex : (Settings?.LeagueClassPlayerOverrideColourHex ?? string.Empty); set { if (!LeagueClassPlayerOverrideIsAutoDetect && Settings != null) { Settings.LeagueClassPlayerOverrideColourHex = value; NotifyLeagueClassUiStatusChanged(); } } }
         public string LeagueClassPlayerPreviewClassName => GetLeagueClassPlayerPreviewResolution().Info.Name ?? string.Empty;
         public string LeagueClassPlayerPreviewShortName => GetLeagueClassPlayerPreviewResolution().Info.ShortName ?? string.Empty;
         public int LeagueClassPlayerPreviewRank => GetLeagueClassPlayerPreviewResolution().Info.Rank;
@@ -6844,6 +6846,46 @@ namespace LaunchPlugin
             }
         }
         public Brush LeagueClassHelperForeground => LeagueClassHelperHasWarning ? Brushes.Yellow : Brushes.LightGray;
+
+        public string LeagueRaceSettingsHeaderText => "LEAGUE RACE - " + GetLeagueClassUiStatusText();
+
+        private string GetLeagueClassUiStatusText()
+        {
+            if (Settings == null || !Settings.LeagueClassEnabled)
+            {
+                return "OFF";
+            }
+
+            var status = LeagueClassStatus;
+            int loaded = status?.LoadedCount ?? 0;
+            int valid = status?.ValidDriverCount ?? 0;
+            int invalid = status?.InvalidRowCount ?? 0;
+            int duplicates = status?.DuplicateRowCount ?? 0;
+            string config = status?.ConfigStatusText ?? string.Empty;
+            string player = LeagueClassPlayerPreviewText ?? string.Empty;
+            bool csvBackedMode = LeagueClassShowCsvSection;
+            bool playerWaiting = player.IndexOf("not available yet", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool invalidManualOverride = player.IndexOf("manual override invalid", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool playerResolved = !invalidManualOverride &&
+                player.IndexOf("Source: NONE", StringComparison.OrdinalIgnoreCase) < 0 &&
+                player.IndexOf("unresolved", StringComparison.OrdinalIgnoreCase) < 0;
+            bool configBad = config.IndexOf("fail", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                config.IndexOf("missing", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                config.IndexOf("invalid", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                config.IndexOf("error", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool rowCountWarning = csvBackedMode && (loaded <= 0 || valid <= 0);
+            bool warning = rowCountWarning || configBad || invalid > 0 || duplicates > 0 || invalidManualOverride || (!playerResolved && !playerWaiting);
+
+            return warning ? "WARNING" : "ACTIVE";
+        }
+
+        private void NotifyLeagueClassUiStatusChanged()
+        {
+            OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+            OnPropertyChanged(nameof(LeagueClassHelperHasWarning));
+            OnPropertyChanged(nameof(LeagueClassHelperForeground));
+            OnPropertyChanged(nameof(LeagueRaceSettingsHeaderText));
+        }
 
         private sealed class LeagueClassPlayerPreviewResolution
         {
@@ -18299,12 +18341,18 @@ namespace LaunchPlugin
                 HookLeagueClassDefinitions(_subscribedLeagueClassSettings?.LeagueClassDefinitions);
                 OnPropertyChanged(nameof(LeagueClassStatus));
                 OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+                OnPropertyChanged(nameof(LeagueRaceSettingsHeaderText));
                 _leagueClassOpponentsRefreshPending = true;
                 return;
             }
 
             if (!string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassEnabled), StringComparison.Ordinal) &&
-                !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassMode), StringComparison.Ordinal))
+                !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassMode), StringComparison.Ordinal) &&
+                !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassPlayerOverrideMode), StringComparison.Ordinal) &&
+                !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassPlayerOverrideClassName), StringComparison.Ordinal) &&
+                !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassPlayerOverrideShortName), StringComparison.Ordinal) &&
+                !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassPlayerOverrideRank), StringComparison.Ordinal) &&
+                !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassPlayerOverrideColourHex), StringComparison.Ordinal))
             {
                 return;
             }
@@ -18316,6 +18364,14 @@ namespace LaunchPlugin
             }
             OnPropertyChanged(nameof(LeagueClassStatus));
             OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+            OnPropertyChanged(nameof(LeagueClassPlayerOverrideIsAutoDetect));
+            OnPropertyChanged(nameof(LeagueClassPlayerClassNameEditorText));
+            OnPropertyChanged(nameof(LeagueClassPlayerShortNameEditorText));
+            OnPropertyChanged(nameof(LeagueClassPlayerRankEditorText));
+            OnPropertyChanged(nameof(LeagueClassPlayerColourHexEditorText));
+            OnPropertyChanged(nameof(LeagueClassHelperHasWarning));
+            OnPropertyChanged(nameof(LeagueClassHelperForeground));
+            OnPropertyChanged(nameof(LeagueRaceSettingsHeaderText));
             OnPropertyChanged(nameof(LeagueClassShowCsvSection));
             OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
             _leagueClassOpponentsRefreshPending = true;
@@ -26660,7 +26716,17 @@ namespace LaunchPlugin
                 OnPropertyChanged(nameof(LeagueClassEnabled));
             }
         }
-        public int LeagueClassMode { get; set; } = 0;
+        private int _leagueClassMode = 0;
+        public int LeagueClassMode
+        {
+            get { return _leagueClassMode; }
+            set
+            {
+                if (_leagueClassMode == value) return;
+                _leagueClassMode = value;
+                OnPropertyChanged(nameof(LeagueClassMode));
+            }
+        }
         private string _leagueClassCsvPath = string.Empty;
         public string LeagueClassCsvPath
         {
@@ -26673,11 +26739,64 @@ namespace LaunchPlugin
                 OnPropertyChanged(nameof(LeagueClassCsvPath));
             }
         }
-        public int LeagueClassPlayerOverrideMode { get; set; } = 0; // 0=Auto,1=Manual
-        public string LeagueClassPlayerOverrideClassName { get; set; } = string.Empty;
-        public string LeagueClassPlayerOverrideShortName { get; set; } = string.Empty;
-        public int LeagueClassPlayerOverrideRank { get; set; } = 0;
-        public string LeagueClassPlayerOverrideColourHex { get; set; } = string.Empty;
+        private int _leagueClassPlayerOverrideMode = 0;
+        public int LeagueClassPlayerOverrideMode
+        {
+            get { return _leagueClassPlayerOverrideMode; }
+            set
+            {
+                if (_leagueClassPlayerOverrideMode == value) return;
+                _leagueClassPlayerOverrideMode = value;
+                OnPropertyChanged(nameof(LeagueClassPlayerOverrideMode));
+            }
+        } // 0=Auto,1=Manual
+        private string _leagueClassPlayerOverrideClassName = string.Empty;
+        public string LeagueClassPlayerOverrideClassName
+        {
+            get { return _leagueClassPlayerOverrideClassName; }
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_leagueClassPlayerOverrideClassName, normalized, StringComparison.Ordinal)) return;
+                _leagueClassPlayerOverrideClassName = normalized;
+                OnPropertyChanged(nameof(LeagueClassPlayerOverrideClassName));
+            }
+        }
+        private string _leagueClassPlayerOverrideShortName = string.Empty;
+        public string LeagueClassPlayerOverrideShortName
+        {
+            get { return _leagueClassPlayerOverrideShortName; }
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_leagueClassPlayerOverrideShortName, normalized, StringComparison.Ordinal)) return;
+                _leagueClassPlayerOverrideShortName = normalized;
+                OnPropertyChanged(nameof(LeagueClassPlayerOverrideShortName));
+            }
+        }
+        private int _leagueClassPlayerOverrideRank = 0;
+        public int LeagueClassPlayerOverrideRank
+        {
+            get { return _leagueClassPlayerOverrideRank; }
+            set
+            {
+                if (_leagueClassPlayerOverrideRank == value) return;
+                _leagueClassPlayerOverrideRank = value;
+                OnPropertyChanged(nameof(LeagueClassPlayerOverrideRank));
+            }
+        }
+        private string _leagueClassPlayerOverrideColourHex = string.Empty;
+        public string LeagueClassPlayerOverrideColourHex
+        {
+            get { return _leagueClassPlayerOverrideColourHex; }
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_leagueClassPlayerOverrideColourHex, normalized, StringComparison.Ordinal)) return;
+                _leagueClassPlayerOverrideColourHex = normalized;
+                OnPropertyChanged(nameof(LeagueClassPlayerOverrideColourHex));
+            }
+        }
         public List<LeagueClassFallbackRule> LeagueClassFallbackRules { get; set; } = new List<LeagueClassFallbackRule>
         {
             new LeagueClassFallbackRule(),

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -6973,6 +6973,7 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(LeagueClassPlayerColourHexEditorText));
             OnPropertyChanged(nameof(LeagueClassHelperHasWarning));
             OnPropertyChanged(nameof(LeagueClassHelperForeground));
+            OnPropertyChanged(nameof(LeagueRaceSettingsHeaderText));
             OnPropertyChanged(nameof(LeagueClassShowCsvSection));
             OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
         }


### PR DESCRIPTION
### Motivation
- Make the collapsed Settings → League Race expander show a compact, informative state so users can see League Class OFF/ACTIVE/WARNING without expanding the section.
- Reuse the same practical status model used by the Overview page while ensuring no visual style/colour, resolver semantics, export contracts, or dashboard behaviour change.

### Description
- Added a UI-only helper property `LeagueRaceSettingsHeaderText` that returns `LEAGUE RACE - OFF/ACTIVE/WARNING` using the Overview-style warning criteria. (no colour/style bindings were introduced).
- Bound the Settings expander `Header` to `LeagueRaceSettingsHeaderText` in `GlobalSettingsView.xaml` so the collapsed header shows the status text.
- Wired property-change notifications and small settings-property conversions so the header updates when League settings, definitions, or manual-override editor fields change, without altering resolver behaviour or persistence names.
- Documentation updates and changelog entries added to reflect the UI change: `GlobalSettingsView.xaml`, `LalaLaunch.cs`, `Docs/Subsystems/League_Class_System.md`, `Docs/User_Guide.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` were modified.

### Testing
- Ran static checks: `git diff --check` passed and repository search (`rg`) verified new binding and helper usage; these succeeded.
- Property Snapshot review: confirmed no SimHub export/property names or snapshot groups were added, removed, renamed, or regrouped.
- Build attempt: `msbuild LaunchPlugin.csproj /p:Configuration=Release /p:Platform=AnyCPU` could not be executed in the container because `msbuild` is not installed (no build run performed).
- Commit created and repository state updated; automated verification steps above completed successfully where available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bffee2b34832f909713a1aedd786a)